### PR TITLE
Fix the Reject renewals for claimable registrations explicitly closes #65 

### DIFF
--- a/contracts/registrar/src/lib.rs
+++ b/contracts/registrar/src/lib.rs
@@ -2,15 +2,14 @@ pub mod expiry;
 pub mod pricing;
 mod test;
 
+use expiry::expiry_from_now;
+use pricing::price_for_label_length;
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
 use xlm_ns_common::soroban::{
     build_xlm_name, extract_label_soroban, validate_label_soroban,
     validate_registration_years_soroban,
 };
 use xlm_ns_common::GRACE_PERIOD_SECONDS;
-
-use expiry::{expiry_from_now, within_grace_period};
-use pricing::price_for_label_length;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -51,6 +50,7 @@ pub enum RegistrarError {
     Reserved = 5,
     Unauthorized = 6,
     Validation = 7,
+    RegistrationClaimable = 8,
 }
 
 #[contract]
@@ -156,8 +156,10 @@ impl RegistrarContract {
         if record.owner != caller {
             return Err(RegistrarError::Unauthorized);
         }
-        if !can_renew(record.expires_at, now_unix) {
-            return Err(RegistrarError::NotRenewable);
+        match can_renew(record.expires_at, now_unix) {
+            Ok(true) => {}
+            Ok(false) => return Err(RegistrarError::NotRenewable),
+            Err(e) => return Err(e),
         }
 
         let fee_due = price_for_label_length(label.len() as usize).saturating_mul(years);
@@ -226,6 +228,12 @@ fn build_quote(label: &String, years: u64, now_unix: u64) -> RegistrationQuote {
     }
 }
 
-pub fn can_renew(expiry_unix: u64, now_unix: u64) -> bool {
-    now_unix <= expiry_unix || within_grace_period(expiry_unix, now_unix)
+pub fn can_renew(expiry_unix: u64, now_unix: u64) -> Result<bool, RegistrarError> {
+    let grace_period_end = expiry_unix.saturating_add(GRACE_PERIOD_SECONDS);
+
+    if now_unix > grace_period_end {
+        return Err(RegistrarError::RegistrationClaimable);
+    }
+
+    Ok(now_unix <= grace_period_end)
 }

--- a/contracts/registrar/src/test.rs
+++ b/contracts/registrar/src/test.rs
@@ -4,7 +4,9 @@ mod tests {
 
     use crate::expiry::{expiry_from_now, within_grace_period};
     use crate::pricing::price_for_label_length;
-    use crate::{can_renew, RegistrarContract, RegistrarContractClient};
+    use crate::{
+        can_renew, RegistrarContract, RegistrarContractClient, RegistrarError, GRACE_PERIOD_SECONDS,
+    };
 
     #[test]
     fn applies_tiered_pricing() {
@@ -17,7 +19,7 @@ mod tests {
     fn computes_expiry_and_grace_period() {
         let expiry = expiry_from_now(100, 1);
         assert!(within_grace_period(expiry, expiry + 10));
-        assert!(can_renew(expiry, expiry + 10));
+        assert!(can_renew(expiry, expiry + 10).unwrap());
     }
 
     #[test]
@@ -39,5 +41,120 @@ mod tests {
         let record = client.registration(&name).unwrap();
         assert_eq!(record.owner, owner);
         assert!(client.treasury_balance() >= quote.fee_stroops * 2);
+    }
+
+    // ==================== Renewal Lifecycle Tests ====================
+
+    #[test]
+    fn can_renew_active_registration_before_expiry() {
+        let now = 1000;
+        let expiry = 2000;
+        let result = can_renew(expiry, now);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn can_renew_at_exact_expiry() {
+        let now = 2000;
+        let expiry = 2000;
+        let result = can_renew(expiry, now);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn can_renew_during_grace_period() {
+        let expiry = 1000;
+        let _grace_end = expiry + GRACE_PERIOD_SECONDS;
+        let now = expiry + 100;
+        let result = can_renew(expiry, now);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn can_renew_at_grace_period_boundary_minus_one() {
+        let expiry = 1000;
+        let grace_end = expiry + GRACE_PERIOD_SECONDS;
+        let now = grace_end - 1;
+        let result = can_renew(expiry, now);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn can_renew_at_exact_grace_period_end() {
+        let expiry = 1000;
+        let grace_end = expiry + GRACE_PERIOD_SECONDS;
+        let now = grace_end;
+        let result = can_renew(expiry, now);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn cannot_renew_claimable_registration_after_grace_period() {
+        let expiry = 1000;
+        let grace_end = expiry + GRACE_PERIOD_SECONDS;
+        let now = grace_end + 1;
+        let result = can_renew(expiry, now);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), RegistrarError::RegistrationClaimable);
+    }
+
+    #[test]
+    fn cannot_renew_claimable_registration_far_future() {
+        let expiry = 1000;
+        let grace_end = expiry + GRACE_PERIOD_SECONDS;
+        let now = grace_end + 1000000;
+        let result = can_renew(expiry, now);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), RegistrarError::RegistrationClaimable);
+    }
+
+    #[test]
+    fn renew_fails_for_claimable_registration() {
+        let env = Env::default();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "test");
+        let name = String::from_str(&env, "test.xlm");
+
+        let quote = client.quote_registration(&label, &1, &100);
+        client.register(&label, &owner, &1, &quote.fee_stroops, &100);
+
+        let grace_end = quote.grace_period_ends_at;
+        let after_grace = grace_end + 1;
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.renew(&name, &owner, &1, &quote.fee_stroops, &after_grace);
+        }));
+        assert!(
+            result.is_err(),
+            "Renewal should fail for claimable registration"
+        );
+    }
+
+    #[test]
+    fn renew_succeeds_at_grace_period_boundary() {
+        let env = Env::default();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "boundary");
+        let name = String::from_str(&env, "boundary.xlm");
+
+        let quote = client.quote_registration(&label, &1, &100);
+        client.register(&label, &owner, &1, &quote.fee_stroops, &100);
+
+        let grace_end = quote.grace_period_ends_at;
+        client.renew(&name, &owner, &1, &quote.fee_stroops, &grace_end);
+
+        let record = client.registration(&name).unwrap();
+        assert!(record.expires_at > quote.expiry_unix);
     }
 }

--- a/contracts/registrar/test_snapshots/test/tests/renew_fails_for_claimable_registration.1.json
+++ b/contracts/registrar/test_snapshots/test/tests/renew_fails_for_claimable_registration.1.json
@@ -1,0 +1,220 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Registration"
+                },
+                {
+                  "string": "test.xlm"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Registration"
+                    },
+                    {
+                      "string": "test.xlm"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "31536100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_paid"
+                      },
+                      "val": {
+                        "u64": "250000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "grace_period_ends_at"
+                      },
+                      "val": {
+                        "u64": "34128100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": "test.xlm"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "registered_at"
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "renewed_at"
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": "250000000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/registrar/test_snapshots/test/tests/renew_succeeds_at_grace_period_boundary.1.json
+++ b/contracts/registrar/test_snapshots/test/tests/renew_succeeds_at_grace_period_boundary.1.json
@@ -1,0 +1,221 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Registration"
+                },
+                {
+                  "string": "boundary.xlm"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Registration"
+                    },
+                    {
+                      "string": "boundary.xlm"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expires_at"
+                      },
+                      "val": {
+                        "u64": "65664100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_paid"
+                      },
+                      "val": {
+                        "u64": "200000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "grace_period_ends_at"
+                      },
+                      "val": {
+                        "u64": "68256100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": "boundary.xlm"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "registered_at"
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "renewed_at"
+                      },
+                      "val": {
+                        "u64": "34128100"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": "200000000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
This is what was done and how
Changes Made
1. Added RegistrationClaimable Error ([lib.rs](file:///home/chukwuemekadr/Documents/Drips/Wave4/xlm-ens/contracts/registrar/src/lib.rs#L53))
New error variant: RegistrationClaimable = 8
Explicitly indicates when a registration has become claimable
2. Updated can_renew Function ([lib.rs](file:///home/chukwuemekadr/Documents/Drips/Wave4/xlm-ens/contracts/registrar/src/lib.rs#L237-L245))
Changed signature from fn can_renew(...) -> bool to fn can_renew(...) -> Result<bool, RegistrarError>
Now explicitly rejects claimable registrations with RegistrationClaimable error
Logic:
✅ current_time <= grace_period_end → Ok(true)
❌ current_time > grace_period_end → Err(RegistrationClaimable)
3. Updated renew Function ([lib.rs](file:///home/chukwuemekadr/Documents/Drips/Wave4/xlm-ens/contracts/registrar/src/lib.rs#L159-L164))
Now properly handles the Result from can_renew
Returns appropriate errors: NotRenewable or RegistrationClaimable
4. Comprehensive Test Suite ([test.rs](file:///home/chukwuemekadr/Documents/Drips/Wave4/xlm-ens/contracts/registrar/src/test.rs))
✅ Valid Renewals (5 tests):
Before expiry
At exact expiry
During grace period
At grace period boundary - 1
At exact grace period end

closes #65 