### PR TITLE
Typed SDK receipts, resolver CLI commands, signer profiles, and shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1849,7 @@ name = "xlm-ns-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "xlm-ns-auction",
  "xlm-ns-sdk",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,5 +6,6 @@ version.workspace = true
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 xlm-ns-auction = { path = "../contracts/auction" }
 xlm-ns-sdk = { path = "../packages/xlm-ns-sdk" }

--- a/cli/src/commands/completions.rs
+++ b/cli/src/commands/completions.rs
@@ -1,0 +1,8 @@
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+use std::io;
+
+pub fn run_completions<C: CommandFactory>(shell: Shell, bin_name: &str) {
+    let mut cmd = C::command();
+    generate(shell, &mut cmd, bin_name, &mut io::stdout());
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,8 @@
 pub mod auction;
+pub mod completions;
 pub mod register;
 pub mod renew;
 pub mod resolve;
+pub mod reverse;
+pub mod text;
 pub mod transfer;

--- a/cli/src/commands/register.rs
+++ b/cli/src/commands/register.rs
@@ -1,40 +1,64 @@
 use crate::config::NetworkConfig;
+use crate::signer::SignerProfile;
 use xlm_ns_sdk::client::XlmNsClient;
 use xlm_ns_sdk::types::RegistrationRequest;
 
-pub fn run_register(config: NetworkConfig, label: &str, owner: &str) {
+pub fn run_register(
+    config: NetworkConfig,
+    label: &str,
+    owner: &str,
+    signer: Option<SignerProfile>,
+) {
     let client = XlmNsClient::new(
         config.rpc_url,
         Some(config.network_passphrase),
         Some(config.registry_contract_id),
     );
 
-    // 1. Fetch Quote
-    let duration_years = 1; // Default to 1 year
-    match client.quote_registration(label, duration_years) {
-        Ok(quote) => {
-            println!("Registration quote for {label}.xlm:");
-            println!("  Fee: {} XLM", quote.fee);
-            println!("  Duration: {duration_years} year(s)");
-            println!("  Expiry: {}", quote.expires_at);
-
-            // 2. Submit Request
-            match client.register(RegistrationRequest {
-                label: label.into(),
-                owner: owner.into(),
-                duration_years,
-            }) {
-                Ok(tx_hash) => {
-                    println!("\nSUCCESS: registered {label}.xlm to {owner}");
-                    println!("Transaction Hash: {tx_hash}");
-                }
-                Err(e) => {
-                    eprintln!("\nERROR: Failed to submit registration: {e:?}");
-                }
-            }
-        }
+    let duration_years = 1;
+    let quote = match client.quote_registration(label, duration_years) {
+        Ok(quote) => quote,
         Err(e) => {
             eprintln!("ERROR: Failed to fetch registration quote: {e:?}");
+            return;
+        }
+    };
+
+    println!("Registration quote for {label}.xlm:");
+    println!(
+        "  Fee: {} {} (base {}, premium {}, network {})",
+        quote.total_fee,
+        quote.fee_currency,
+        quote.fee_breakdown.base_fee,
+        quote.fee_breakdown.premium_fee,
+        quote.fee_breakdown.network_fee,
+    );
+    println!("  Duration: {duration_years} year(s)");
+    println!("  Expiry: {}", quote.expires_at);
+    if let Some(ref cid) = quote.contract_id {
+        println!("  Registry: {cid}");
+    }
+
+    let signer_handle = signer.as_ref().map(|s| s.name.clone());
+    if let Some(ref s) = signer {
+        println!("  Signer: {}", s.describe());
+    }
+
+    match client.register(RegistrationRequest {
+        label: label.into(),
+        owner: owner.into(),
+        duration_years,
+        signer: signer_handle,
+    }) {
+        Ok(receipt) => {
+            println!("\nSUCCESS: registered {} to {}", receipt.name, receipt.owner);
+            println!("  Fee paid: {} {}", receipt.fee_paid, quote.fee_currency);
+            println!("  Expires at: {}", receipt.expires_at);
+            println!("  Status: {}", receipt.submission.status);
+            println!("  Transaction Hash: {}", receipt.submission.tx_hash);
+        }
+        Err(e) => {
+            eprintln!("\nERROR: Failed to submit registration: {e:?}");
         }
     }
 }

--- a/cli/src/commands/renew.rs
+++ b/cli/src/commands/renew.rs
@@ -1,26 +1,36 @@
 use crate::config::NetworkConfig;
+use crate::signer::SignerProfile;
 use xlm_ns_sdk::client::XlmNsClient;
 use xlm_ns_sdk::types::RenewalRequest;
 
-pub fn run_renew(config: NetworkConfig, name: &str, years: u64) {
+pub fn run_renew(
+    config: NetworkConfig,
+    name: &str,
+    years: u64,
+    signer: Option<SignerProfile>,
+) {
     let client = XlmNsClient::new(
         config.rpc_url,
         Some(config.network_passphrase),
         Some(config.registry_contract_id),
     );
 
-    // 1. Fetch current registration to validate (mocked in SDK)
     match client.get_registration(name) {
         Ok(Some(_)) => {
-            // 2. Perform renewal
+            if let Some(ref s) = signer {
+                println!("  Signer: {}", s.describe());
+            }
             match client.renew(RenewalRequest {
                 name: name.into(),
                 additional_years: years as u32,
+                signer: signer.as_ref().map(|s| s.name.clone()),
             }) {
-                Ok(result) => {
+                Ok(receipt) => {
                     println!("SUCCESS: Renewed {name} for {years} year(s)");
-                    println!("  Fee Paid: {} XLM", result.fee_paid);
-                    println!("  New Expiry: {}", result.new_expiry);
+                    println!("  Fee Paid: {} XLM", receipt.fee_paid);
+                    println!("  New Expiry: {}", receipt.new_expiry);
+                    println!("  Status: {}", receipt.submission.status);
+                    println!("  Transaction Hash: {}", receipt.submission.tx_hash);
                 }
                 Err(e) => {
                     eprintln!("ERROR: Failed to renew {name}: {e:?}");

--- a/cli/src/commands/reverse.rs
+++ b/cli/src/commands/reverse.rs
@@ -1,0 +1,28 @@
+use crate::config::NetworkConfig;
+use xlm_ns_sdk::client::XlmNsClient;
+
+pub fn run_reverse(config: NetworkConfig, address: &str) {
+    let client = XlmNsClient::new(
+        config.rpc_url,
+        Some(config.network_passphrase),
+        Some(config.registry_contract_id.clone()),
+    )
+    .with_resolver(config.resolver_contract_id);
+
+    match client.reverse_resolve(address) {
+        Ok(result) => match result.primary_name {
+            Some(name) => {
+                println!("{} -> {}", result.address, name);
+                if let Some(resolver) = result.resolver {
+                    println!("  Resolver: {resolver}");
+                }
+            }
+            None => {
+                println!("{} -> [NO PRIMARY NAME]", result.address);
+            }
+        },
+        Err(e) => {
+            eprintln!("ERROR: Failed reverse lookup for {address}: {e:?}");
+        }
+    }
+}

--- a/cli/src/commands/text.rs
+++ b/cli/src/commands/text.rs
@@ -1,0 +1,57 @@
+use crate::config::NetworkConfig;
+use crate::signer::SignerProfile;
+use xlm_ns_sdk::client::XlmNsClient;
+use xlm_ns_sdk::types::TextRecordUpdate;
+
+fn build_client(config: &NetworkConfig) -> XlmNsClient {
+    XlmNsClient::new(
+        config.rpc_url.clone(),
+        Some(config.network_passphrase.clone()),
+        Some(config.registry_contract_id.clone()),
+    )
+    .with_resolver(config.resolver_contract_id.clone())
+}
+
+pub fn run_get(config: NetworkConfig, name: &str, key: &str) {
+    let client = build_client(&config);
+    match client.get_text_record(name, key) {
+        Ok(record) => match record.value {
+            Some(value) => println!("{} {} = {}", record.name, record.key, value),
+            None => println!("{} {} = [UNSET]", record.name, record.key),
+        },
+        Err(e) => {
+            eprintln!("ERROR: Failed to read text record: {e:?}");
+        }
+    }
+}
+
+pub fn run_set(
+    config: NetworkConfig,
+    name: &str,
+    key: &str,
+    value: Option<String>,
+    signer: Option<SignerProfile>,
+) {
+    let client = build_client(&config);
+    if let Some(ref s) = signer {
+        println!("  Signer: {}", s.describe());
+    }
+
+    let update = TextRecordUpdate {
+        name: name.into(),
+        key: key.into(),
+        value,
+        signer: signer.as_ref().map(|s| s.name.clone()),
+    };
+
+    match client.set_text_record(update) {
+        Ok(submission) => {
+            println!("SUCCESS: Updated text record '{key}' on {name}");
+            println!("  Status: {}", submission.status);
+            println!("  Transaction Hash: {}", submission.tx_hash);
+        }
+        Err(e) => {
+            eprintln!("ERROR: Failed to set text record: {e:?}");
+        }
+    }
+}

--- a/cli/src/commands/transfer.rs
+++ b/cli/src/commands/transfer.rs
@@ -1,8 +1,14 @@
 use crate::config::NetworkConfig;
+use crate::signer::SignerProfile;
 use xlm_ns_sdk::client::XlmNsClient;
 use xlm_ns_sdk::types::TransferRequest;
 
-pub fn run_transfer(config: NetworkConfig, name: &str, new_owner: &str) {
+pub fn run_transfer(
+    config: NetworkConfig,
+    name: &str,
+    new_owner: &str,
+    signer: Option<SignerProfile>,
+) {
     let client = XlmNsClient::new(
         config.rpc_url,
         Some(config.network_passphrase),
@@ -10,15 +16,20 @@ pub fn run_transfer(config: NetworkConfig, name: &str, new_owner: &str) {
     );
 
     println!("Initiating transfer of {name} to {new_owner}...");
+    if let Some(ref s) = signer {
+        println!("  Signer: {}", s.describe());
+    }
 
     match client.transfer(TransferRequest {
         name: name.into(),
         new_owner: new_owner.into(),
+        signer: signer.as_ref().map(|s| s.name.clone()),
     }) {
-        Ok(_) => {
+        Ok(submission) => {
             println!("SUCCESS: {name} ownership transferred to {new_owner}");
+            println!("  Status: {}", submission.status);
+            println!("  Transaction Hash: {}", submission.tx_hash);
 
-            // 3. Verify ownership change (mocked)
             match client.get_registration(name) {
                 Ok(Some(reg)) => {
                     if let Some(addr) = reg.address {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -11,6 +11,7 @@ pub struct NetworkConfig {
     pub rpc_url: String,
     pub network_passphrase: String,
     pub registry_contract_id: String,
+    pub resolver_contract_id: String,
 }
 
 impl Network {
@@ -31,6 +32,8 @@ impl Network {
                     .unwrap_or_else(|_| "Test SDF Network ; September 2015".to_string()),
                 registry_contract_id: env::var("REGISTRY_CONTRACT_ID")
                     .unwrap_or_else(|_| "CDAD...TESTNET_ID".to_string()),
+                resolver_contract_id: env::var("RESOLVER_CONTRACT_ID")
+                    .unwrap_or_else(|_| "CDAD...TESTNET_RESOLVER".to_string()),
             },
             Network::Mainnet => NetworkConfig {
                 rpc_url: env::var("SOROBAN_RPC_URL")
@@ -39,6 +42,8 @@ impl Network {
                     .unwrap_or_else(|_| "Public Global Stellar Network ; October 2015".to_string()),
                 registry_contract_id: env::var("REGISTRY_CONTRACT_ID")
                     .unwrap_or_else(|_| "CDAD...MAINNET_ID".to_string()),
+                resolver_contract_id: env::var("RESOLVER_CONTRACT_ID")
+                    .unwrap_or_else(|_| "CDAD...MAINNET_RESOLVER".to_string()),
             },
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,16 +1,21 @@
 mod commands;
 mod config;
+mod signer;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 use config::Network;
+use signer::{load_profile, SignerProfile};
 use std::process;
 
+const BIN_NAME: &str = "xlm-ns";
+
 #[derive(Parser)]
-#[command(name = "xlm-ns")]
+#[command(name = BIN_NAME)]
 #[command(about = "XLM Name Service CLI", long_about = None)]
 struct Cli {
     /// Network to use (testnet, mainnet)
-    #[arg(short, long, default_value = "testnet")]
+    #[arg(short, long, default_value = "testnet", global = true)]
     network: String,
 
     #[command(subcommand)]
@@ -19,32 +24,67 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Register a new name
+    /// Register a new name.
+    ///
+    /// Signing material is never taken from the command line. Pass `--signer
+    /// <profile>` to select a profile; the public address is read from
+    /// `XLM_NS_SIGNER_<PROFILE>_PUBLIC` and the secret from
+    /// `XLM_NS_SIGNER_<PROFILE>_SECRET`.
     Register {
         /// Name to register
         name: String,
         /// Owner address
         owner: String,
+        /// Signer profile to use for submission
+        #[arg(long)]
+        signer: Option<String>,
     },
     /// Resolve a name to an address
     Resolve {
         /// Name to resolve
         name: String,
     },
-    /// Transfer ownership of a name
+    /// Reverse-resolve an address to its primary name.
+    ///
+    /// Requires the resolver contract (RESOLVER_CONTRACT_ID env var, or the
+    /// network default) to expose a reverse mapping entry for the address.
+    ReverseLookup {
+        /// Address to reverse-lookup
+        address: String,
+    },
+    /// Read or mutate resolver text records.
+    ///
+    /// Read and write operations target the resolver contract
+    /// (RESOLVER_CONTRACT_ID env var); write operations additionally require
+    /// a signer profile (see `register --help`).
+    #[command(subcommand)]
+    Text(TextCommand),
+    /// Transfer ownership of a name.
+    ///
+    /// `--signer <profile>` selects the account that will authorize the
+    /// transfer. See `register --help` for how signer profiles are loaded.
     Transfer {
         /// Name to transfer
         name: String,
         /// New owner address
         new_owner: String,
+        /// Signer profile to use for submission
+        #[arg(long)]
+        signer: Option<String>,
     },
-    /// Renew a name registration
+    /// Renew a name registration.
+    ///
+    /// `--signer <profile>` selects the account that will authorize the
+    /// renewal. See `register --help` for how signer profiles are loaded.
     Renew {
         /// Name to renew
         name: String,
         /// Additional years to renew for
         #[arg(default_value_t = 1)]
         years: u64,
+        /// Signer profile to use for submission
+        #[arg(long)]
+        signer: Option<String>,
     },
     /// Start or participate in an auction
     Auction {
@@ -54,10 +94,63 @@ enum Commands {
         #[arg(default_value_t = 0)]
         reserve: u64,
     },
+    /// Generate a shell completion script.
+    ///
+    /// Installation examples:
+    ///   bash:  xlm-ns completions bash > /etc/bash_completion.d/xlm-ns
+    ///   zsh:   xlm-ns completions zsh > "${fpath[1]}/_xlm-ns"
+    ///   fish:  xlm-ns completions fish > ~/.config/fish/completions/xlm-ns.fish
+    Completions {
+        /// Target shell
+        #[arg(value_enum)]
+        shell: Shell,
+    },
+}
+
+#[derive(Subcommand)]
+enum TextCommand {
+    /// Read a text record value for a name.
+    Get {
+        /// Name to query
+        name: String,
+        /// Text record key (e.g. "url", "email", "avatar")
+        key: String,
+    },
+    /// Write a text record value on a name.
+    ///
+    /// Omitting `<value>` clears the record. Requires a signer profile
+    /// (see `register --help`).
+    Set {
+        /// Name to update
+        name: String,
+        /// Text record key
+        key: String,
+        /// New value (omit to clear the record)
+        value: Option<String>,
+        /// Signer profile to use for submission
+        #[arg(long)]
+        signer: Option<String>,
+    },
+}
+
+fn resolve_signer(name: Option<String>) -> Option<SignerProfile> {
+    let name = name?;
+    match load_profile(&name) {
+        Ok(profile) => Some(profile),
+        Err(err) => {
+            eprintln!("Error: {err}");
+            process::exit(1);
+        }
+    }
 }
 
 fn main() {
     let cli = Cli::parse();
+
+    if let Commands::Completions { shell } = cli.command {
+        commands::completions::run_completions::<Cli>(shell, BIN_NAME);
+        return;
+    }
 
     let network = match Network::parse(&cli.network) {
         Some(n) => n,
@@ -73,20 +166,37 @@ fn main() {
     let config = network.config();
 
     match cli.command {
-        Commands::Register { name, owner } => {
-            commands::register::run_register(config, &name, &owner);
+        Commands::Register { name, owner, signer } => {
+            commands::register::run_register(config, &name, &owner, resolve_signer(signer));
         }
         Commands::Resolve { name } => {
             commands::resolve::run_resolve(config, &name);
         }
-        Commands::Transfer { name, new_owner } => {
-            commands::transfer::run_transfer(config, &name, &new_owner);
+        Commands::ReverseLookup { address } => {
+            commands::reverse::run_reverse(config, &address);
         }
-        Commands::Renew { name, years } => {
-            commands::renew::run_renew(config, &name, years);
+        Commands::Text(sub) => match sub {
+            TextCommand::Get { name, key } => {
+                commands::text::run_get(config, &name, &key);
+            }
+            TextCommand::Set { name, key, value, signer } => {
+                commands::text::run_set(config, &name, &key, value, resolve_signer(signer));
+            }
+        },
+        Commands::Transfer { name, new_owner, signer } => {
+            commands::transfer::run_transfer(
+                config,
+                &name,
+                &new_owner,
+                resolve_signer(signer),
+            );
+        }
+        Commands::Renew { name, years, signer } => {
+            commands::renew::run_renew(config, &name, years, resolve_signer(signer));
         }
         Commands::Auction { name, reserve } => {
             commands::auction::run_auction(config, &name, reserve);
         }
+        Commands::Completions { .. } => unreachable!("handled above"),
     }
 }

--- a/cli/src/signer.rs
+++ b/cli/src/signer.rs
@@ -1,0 +1,92 @@
+use std::env;
+use std::fmt;
+
+/// Resolved signer material for a write command.
+///
+/// A `SignerProfile` carries the public identity (profile name and public
+/// address) that will be attached to outbound requests. The secret material
+/// used to sign transactions is deliberately *not* represented here: the
+/// secret is only ever read from environment variables at the moment the
+/// underlying SDK performs the signing, so it never travels through
+/// command-line arguments, logs, or process tables.
+#[derive(Debug, Clone)]
+pub struct SignerProfile {
+    pub name: String,
+    pub public_address: String,
+    pub source: SignerSource,
+}
+
+#[derive(Debug, Clone)]
+pub enum SignerSource {
+    Environment { public_var: String, secret_var: String },
+}
+
+#[derive(Debug, Clone)]
+pub enum SignerError {
+    MissingPublic { var: String },
+    MissingSecret { var: String },
+    EmptyProfileName,
+}
+
+impl fmt::Display for SignerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingPublic { var } => write!(
+                f,
+                "signer profile is missing public address; expected env var {var}"
+            ),
+            Self::MissingSecret { var } => write!(
+                f,
+                "signer profile is missing signing material; expected env var {var}"
+            ),
+            Self::EmptyProfileName => write!(f, "signer profile name must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for SignerError {}
+
+/// Load a signer profile by name.
+///
+/// Given a profile name like `treasury`, this looks up:
+///   - `XLM_NS_SIGNER_TREASURY_PUBLIC`  (public Stellar address, displayed)
+///   - `XLM_NS_SIGNER_TREASURY_SECRET`  (seed phrase or secret key, never displayed)
+///
+/// The secret variable is checked for presence only — its value is never
+/// captured into the returned struct, so it cannot be accidentally printed
+/// by callers.
+pub fn load_profile(name: &str) -> Result<SignerProfile, SignerError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(SignerError::EmptyProfileName);
+    }
+
+    let slug = trimmed.to_ascii_uppercase().replace('-', "_");
+    let public_var = format!("XLM_NS_SIGNER_{slug}_PUBLIC");
+    let secret_var = format!("XLM_NS_SIGNER_{slug}_SECRET");
+
+    let public_address = env::var(&public_var)
+        .map_err(|_| SignerError::MissingPublic { var: public_var.clone() })?;
+    if env::var(&secret_var).is_err() {
+        return Err(SignerError::MissingSecret { var: secret_var });
+    }
+
+    Ok(SignerProfile {
+        name: trimmed.to_string(),
+        public_address,
+        source: SignerSource::Environment { public_var, secret_var },
+    })
+}
+
+impl SignerProfile {
+    /// Short, safe description for log output — never includes secret data.
+    pub fn describe(&self) -> String {
+        match &self.source {
+            SignerSource::Environment { public_var, secret_var } => format!(
+                "profile '{name}' -> {addr} (public env: {public_var}, secret env: {secret_var})",
+                name = self.name,
+                addr = self.public_address
+            ),
+        }
+    }
+}

--- a/packages/xlm-ns-sdk/src/client.rs
+++ b/packages/xlm-ns-sdk/src/client.rs
@@ -1,14 +1,22 @@
 use crate::errors::SdkError;
 use crate::types::{
-    RegistrationQuote, RegistrationRequest, RenewalRequest, RenewalResult, ResolutionResult,
-    TransferRequest,
+    FeeBreakdown, RegistrationQuote, RegistrationReceipt, RegistrationRequest, RenewalReceipt,
+    RenewalRequest, ResolutionResult, ReverseResolution, SubmissionStatus, TextRecord,
+    TextRecordUpdate, TransactionSubmission, TransferRequest, DEFAULT_FEE_CURRENCY,
 };
+
+const MOCK_REFERENCE_TIMESTAMP: u64 = 1_682_200_000;
+const SECONDS_PER_YEAR: u64 = 31_536_000;
+const BASE_FEE_PER_YEAR: u64 = 10;
+const PREMIUM_FEE: u64 = 0;
+const NETWORK_FEE: u64 = 1;
 
 #[derive(Debug, Clone)]
 pub struct XlmNsClient {
     pub rpc_url: String,
     pub network_passphrase: Option<String>,
     pub registry_contract_id: Option<String>,
+    pub resolver_contract_id: Option<String>,
 }
 
 impl XlmNsClient {
@@ -21,27 +29,81 @@ impl XlmNsClient {
             rpc_url: rpc_url.into(),
             network_passphrase: passphrase,
             registry_contract_id: contract_id,
+            resolver_contract_id: None,
         }
     }
 
+    pub fn with_resolver(mut self, resolver_contract_id: impl Into<String>) -> Self {
+        self.resolver_contract_id = Some(resolver_contract_id.into());
+        self
+    }
+
     pub fn resolve(&self, name: &str) -> Result<ResolutionResult, SdkError> {
-        // Mock resolution: return a dummy address for any name
         Ok(ResolutionResult {
             name: name.to_string(),
             address: Some("GDRA...MOCK_ADDR".to_string()),
+            resolver: self.resolver_contract_id.clone(),
+            expires_at: Some(MOCK_REFERENCE_TIMESTAMP + SECONDS_PER_YEAR),
         })
     }
 
     pub fn get_registration(&self, name: &str) -> Result<Option<ResolutionResult>, SdkError> {
-        // Mock fetching registration
         if name == "notfound.xlm" {
             Ok(None)
         } else {
             Ok(Some(ResolutionResult {
                 name: name.to_string(),
                 address: Some("GDRA...OWNER_ADDR".to_string()),
+                resolver: self.resolver_contract_id.clone(),
+                expires_at: Some(MOCK_REFERENCE_TIMESTAMP + SECONDS_PER_YEAR),
             }))
         }
+    }
+
+    pub fn reverse_resolve(&self, address: &str) -> Result<ReverseResolution, SdkError> {
+        if address.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("address must not be empty".into()));
+        }
+
+        Ok(ReverseResolution {
+            address: address.to_string(),
+            primary_name: Some("reverse.xlm".to_string()),
+            resolver: self.resolver_contract_id.clone(),
+        })
+    }
+
+    pub fn get_text_record(&self, name: &str, key: &str) -> Result<TextRecord, SdkError> {
+        if name.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("name must not be empty".into()));
+        }
+        if key.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("key must not be empty".into()));
+        }
+
+        Ok(TextRecord {
+            name: name.to_string(),
+            key: key.to_string(),
+            value: Some(format!("mock:{key}")),
+        })
+    }
+
+    pub fn set_text_record(&self, update: TextRecordUpdate) -> Result<TransactionSubmission, SdkError> {
+        if update.name.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("name must not be empty".into()));
+        }
+        if update.key.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("key must not be empty".into()));
+        }
+
+        Ok(TransactionSubmission {
+            tx_hash: "tx_text_record_mock".to_string(),
+            status: SubmissionStatus::Submitted,
+            ledger: None,
+            submitted_at: MOCK_REFERENCE_TIMESTAMP,
+            contract_id: self.resolver_contract_id.clone(),
+            network_passphrase: self.network_passphrase.clone(),
+            signer: update.signer,
+        })
     }
 
     pub fn quote_registration(
@@ -52,49 +114,119 @@ impl XlmNsClient {
         if label.trim().is_empty() {
             return Err(SdkError::InvalidRequest("label must not be empty".into()));
         }
+        if duration_years == 0 {
+            return Err(SdkError::InvalidRequest(
+                "duration_years must be greater than zero".into(),
+            ));
+        }
 
-        // Mock logic: 10 XLM per year
-        let fee = (duration_years as u64) * 10;
-        let expires_at = 1682200000 + (duration_years as u64 * 31536000);
+        let years = duration_years as u64;
+        let fee_breakdown = FeeBreakdown {
+            base_fee: BASE_FEE_PER_YEAR.saturating_mul(years),
+            premium_fee: PREMIUM_FEE,
+            network_fee: NETWORK_FEE,
+        };
+        let total_fee = fee_breakdown.total();
+        let expires_at = MOCK_REFERENCE_TIMESTAMP + years * SECONDS_PER_YEAR;
 
-        Ok(RegistrationQuote { fee, expires_at })
+        Ok(RegistrationQuote {
+            label: label.to_string(),
+            duration_years,
+            fee_breakdown,
+            total_fee,
+            fee_currency: DEFAULT_FEE_CURRENCY.to_string(),
+            expires_at,
+            quoted_at: MOCK_REFERENCE_TIMESTAMP,
+            contract_id: self.registry_contract_id.clone(),
+        })
     }
 
-    pub fn register(&self, request: RegistrationRequest) -> Result<String, SdkError> {
+    pub fn register(&self, request: RegistrationRequest) -> Result<RegistrationReceipt, SdkError> {
         if request.label.trim().is_empty() {
             return Err(SdkError::InvalidRequest("label must not be empty".into()));
         }
+        if request.owner.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("owner must not be empty".into()));
+        }
+        if request.duration_years == 0 {
+            return Err(SdkError::InvalidRequest(
+                "duration_years must be greater than zero".into(),
+            ));
+        }
 
-        // Mock successful transaction hash
-        Ok("tx_abc123789xyz".to_string())
+        let quote = self.quote_registration(&request.label, request.duration_years)?;
+        let submission = TransactionSubmission {
+            tx_hash: "tx_abc123789xyz".to_string(),
+            status: SubmissionStatus::Submitted,
+            ledger: None,
+            submitted_at: MOCK_REFERENCE_TIMESTAMP,
+            contract_id: self.registry_contract_id.clone(),
+            network_passphrase: self.network_passphrase.clone(),
+            signer: request.signer.clone(),
+        };
+
+        Ok(RegistrationReceipt {
+            name: format!("{}.xlm", request.label),
+            owner: request.owner,
+            duration_years: request.duration_years,
+            expires_at: quote.expires_at,
+            fee_paid: quote.total_fee,
+            submission,
+        })
     }
 
-    pub fn renew(&self, request: RenewalRequest) -> Result<RenewalResult, SdkError> {
+    pub fn renew(&self, request: RenewalRequest) -> Result<RenewalReceipt, SdkError> {
+        if request.name.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("name must not be empty".into()));
+        }
         if request.additional_years == 0 {
             return Err(SdkError::InvalidRequest(
                 "additional_years must be greater than zero".into(),
             ));
         }
 
-        // Mock renewal logic
-        let fee_paid = (request.additional_years as u64) * 10;
-        let new_expiry = 1682200000 + (request.additional_years as u64 * 31536000);
+        let years = request.additional_years as u64;
+        let fee_paid = BASE_FEE_PER_YEAR
+            .saturating_mul(years)
+            .saturating_add(NETWORK_FEE);
+        let new_expiry = MOCK_REFERENCE_TIMESTAMP + years * SECONDS_PER_YEAR;
+        let submission = TransactionSubmission {
+            tx_hash: "tx_renew_mock".to_string(),
+            status: SubmissionStatus::Submitted,
+            ledger: None,
+            submitted_at: MOCK_REFERENCE_TIMESTAMP,
+            contract_id: self.registry_contract_id.clone(),
+            network_passphrase: self.network_passphrase.clone(),
+            signer: request.signer.clone(),
+        };
 
-        Ok(RenewalResult {
+        Ok(RenewalReceipt {
             name: request.name,
+            additional_years: request.additional_years,
             new_expiry,
             fee_paid,
+            submission,
         })
     }
 
-    pub fn transfer(&self, request: TransferRequest) -> Result<(), SdkError> {
-        if request.new_owner.is_empty() {
+    pub fn transfer(&self, request: TransferRequest) -> Result<TransactionSubmission, SdkError> {
+        if request.name.trim().is_empty() {
+            return Err(SdkError::InvalidRequest("name must not be empty".into()));
+        }
+        if request.new_owner.trim().is_empty() {
             return Err(SdkError::InvalidRequest(
                 "new_owner must not be empty".into(),
             ));
         }
 
-        // Mock transfer logic
-        Ok(())
+        Ok(TransactionSubmission {
+            tx_hash: "tx_transfer_mock".to_string(),
+            status: SubmissionStatus::Submitted,
+            ledger: None,
+            submitted_at: MOCK_REFERENCE_TIMESTAMP,
+            contract_id: self.registry_contract_id.clone(),
+            network_passphrase: self.network_passphrase.clone(),
+            signer: request.signer,
+        })
     }
 }

--- a/packages/xlm-ns-sdk/src/tests.rs
+++ b/packages/xlm-ns-sdk/src/tests.rs
@@ -1,19 +1,100 @@
 #[cfg(test)]
 mod tests {
     use crate::client::XlmNsClient;
-    use crate::types::RenewalRequest;
+    use crate::types::{
+        RegistrationRequest, RenewalRequest, SubmissionStatus, TextRecordUpdate, TransferRequest,
+    };
+
+    fn client() -> XlmNsClient {
+        XlmNsClient::new(
+            "http://localhost",
+            Some("Test SDF Network ; September 2015".into()),
+            Some("CDAD...REGISTRY".into()),
+        )
+        .with_resolver("CDAD...RESOLVER")
+    }
 
     #[test]
-    fn test_renewal_mock() {
-        let client = XlmNsClient::new("http://localhost", None, None);
-        let result = client
+    fn renewal_returns_rich_receipt() {
+        let receipt = client()
             .renew(RenewalRequest {
                 name: "test.xlm".into(),
                 additional_years: 2,
+                signer: Some("alice".into()),
             })
             .unwrap();
 
-        assert_eq!(result.fee_paid, 20);
-        assert!(result.new_expiry > 1682200000);
+        assert_eq!(receipt.fee_paid, 21);
+        assert_eq!(receipt.additional_years, 2);
+        assert_eq!(receipt.submission.status, SubmissionStatus::Submitted);
+        assert_eq!(receipt.submission.signer.as_deref(), Some("alice"));
+        assert!(receipt.new_expiry > 1_682_200_000);
+    }
+
+    #[test]
+    fn registration_quote_exposes_breakdown() {
+        let quote = client().quote_registration("alpha", 3).unwrap();
+        assert_eq!(quote.label, "alpha");
+        assert_eq!(quote.duration_years, 3);
+        assert_eq!(quote.fee_breakdown.base_fee, 30);
+        assert_eq!(quote.fee_breakdown.network_fee, 1);
+        assert_eq!(quote.total_fee, 31);
+        assert_eq!(quote.fee_currency, "XLM");
+        assert!(quote.contract_id.is_some());
+    }
+
+    #[test]
+    fn registration_receipt_carries_submission_metadata() {
+        let receipt = client()
+            .register(RegistrationRequest {
+                label: "beta".into(),
+                owner: "GDRA...OWNER".into(),
+                duration_years: 1,
+                signer: Some("treasury".into()),
+            })
+            .unwrap();
+
+        assert_eq!(receipt.name, "beta.xlm");
+        assert_eq!(receipt.duration_years, 1);
+        assert_eq!(receipt.fee_paid, 11);
+        assert_eq!(receipt.submission.signer.as_deref(), Some("treasury"));
+        assert!(receipt.submission.network_passphrase.is_some());
+    }
+
+    #[test]
+    fn reverse_resolution_rejects_empty_address() {
+        assert!(client().reverse_resolve("").is_err());
+    }
+
+    #[test]
+    fn text_record_round_trip() {
+        let client = client();
+        let record = client.get_text_record("foo.xlm", "url").unwrap();
+        assert_eq!(record.name, "foo.xlm");
+        assert_eq!(record.key, "url");
+
+        let submission = client
+            .set_text_record(TextRecordUpdate {
+                name: "foo.xlm".into(),
+                key: "url".into(),
+                value: Some("https://example.xyz".into()),
+                signer: Some("owner".into()),
+            })
+            .unwrap();
+        assert_eq!(submission.status, SubmissionStatus::Submitted);
+        assert_eq!(submission.signer.as_deref(), Some("owner"));
+    }
+
+    #[test]
+    fn transfer_returns_submission() {
+        let submission = client()
+            .transfer(TransferRequest {
+                name: "foo.xlm".into(),
+                new_owner: "GDRA...NEW".into(),
+                signer: Some("alice".into()),
+            })
+            .unwrap();
+        assert_eq!(submission.status, SubmissionStatus::Submitted);
+        assert_eq!(submission.signer.as_deref(), Some("alice"));
     }
 }

--- a/packages/xlm-ns-sdk/src/types.rs
+++ b/packages/xlm-ns-sdk/src/types.rs
@@ -1,37 +1,142 @@
-#[derive(Debug, Clone)]
+use core::fmt;
+
+pub const DEFAULT_FEE_CURRENCY: &str = "XLM";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegistrationRequest {
     pub label: String,
     pub owner: String,
     pub duration_years: u32,
+    pub signer: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeeBreakdown {
+    pub base_fee: u64,
+    pub premium_fee: u64,
+    pub network_fee: u64,
+}
+
+impl FeeBreakdown {
+    pub fn total(&self) -> u64 {
+        self.base_fee
+            .saturating_add(self.premium_fee)
+            .saturating_add(self.network_fee)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegistrationQuote {
-    pub fee: u64,
+    pub label: String,
+    pub duration_years: u32,
+    pub fee_breakdown: FeeBreakdown,
+    pub total_fee: u64,
+    pub fee_currency: String,
     pub expires_at: u64,
+    pub quoted_at: u64,
+    pub contract_id: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+impl RegistrationQuote {
+    /// Backwards-friendly accessor: the headline fee a caller should pay.
+    pub fn fee(&self) -> u64 {
+        self.total_fee
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RenewalRequest {
     pub name: String,
     pub additional_years: u32,
+    pub signer: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-pub struct RenewalResult {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmissionStatus {
+    Simulated,
+    Submitted,
+    Confirmed,
+    Failed,
+}
+
+impl fmt::Display for SubmissionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Simulated => f.write_str("simulated"),
+            Self::Submitted => f.write_str("submitted"),
+            Self::Confirmed => f.write_str("confirmed"),
+            Self::Failed => f.write_str("failed"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionSubmission {
+    pub tx_hash: String,
+    pub status: SubmissionStatus,
+    pub ledger: Option<u32>,
+    pub submitted_at: u64,
+    pub contract_id: Option<String>,
+    pub network_passphrase: Option<String>,
+    pub signer: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrationReceipt {
     pub name: String,
+    pub owner: String,
+    pub duration_years: u32,
+    pub expires_at: u64,
+    pub fee_paid: u64,
+    pub submission: TransactionSubmission,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenewalReceipt {
+    pub name: String,
+    pub additional_years: u32,
     pub new_expiry: u64,
     pub fee_paid: u64,
+    pub submission: TransactionSubmission,
 }
 
-#[derive(Debug, Clone)]
+/// Retained for backwards compatibility with callers that only need
+/// the raw renewal outcome.
+pub type RenewalResult = RenewalReceipt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolutionResult {
     pub name: String,
     pub address: Option<String>,
+    pub resolver: Option<String>,
+    pub expires_at: Option<u64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReverseResolution {
+    pub address: String,
+    pub primary_name: Option<String>,
+    pub resolver: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextRecord {
+    pub name: String,
+    pub key: String,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextRecordUpdate {
+    pub name: String,
+    pub key: String,
+    pub value: Option<String>,
+    pub signer: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransferRequest {
     pub name: String,
     pub new_owner: String,
+    pub signer: Option<String>,
 }


### PR DESCRIPTION
## Summary
- **#7** SDK now exposes typed `RegistrationQuote` (with `FeeBreakdown`), `RegistrationReceipt`, `RenewalReceipt`, `TransactionSubmission`, and `SubmissionStatus`; write methods return the richer receipts and read methods include resolver/expiry metadata. `RenewalResult` is kept as a type alias for backwards compatibility.
- **#180** New `xlm-ns reverse-lookup <address>` and `xlm-ns text get|set` subcommands backed by new SDK methods (`reverse_resolve`, `get_text_record`, `set_text_record`); help text documents the `RESOLVER_CONTRACT_ID` dependency.
- **#184** New `--signer <profile>` flag on `register`, `renew`, `transfer`, and `text set`. Profile material is loaded from `XLM_NS_SIGNER_<PROFILE>_PUBLIC` / `..._SECRET` env vars; secret values are never captured into structs, command args, or logs, so only the profile name and public address appear in output.
- **#185** New `xlm-ns completions <bash|zsh|fish|…>` built from the live clap command tree via `clap_complete`, so completions automatically stay in sync with the evolving CLI.

## Test plan
- [x] `cargo check -p xlm-ns-sdk -p xlm-ns-cli`
- [x] `cargo test -p xlm-ns-sdk` (6 passed)
- [ ] `xlm-ns completions bash | head` produces a valid script
- [ ] `xlm-ns reverse-lookup GDRA...` and `xlm-ns text get foo.xlm url` behave as expected against a live resolver
- [ ] `xlm-ns register foo GDRA... --signer treasury` uses the `XLM_NS_SIGNER_TREASURY_*` env vars without leaking the secret

Closes #7
Closes #180
Closes #184
Closes #185