### PR TITLE
Docs + bootstrap + nightly canary checks

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -1,0 +1,26 @@
+name: Nightly canary (public endpoints)
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: testnet
+            rpc_url: https://soroban-testnet.stellar.org
+          - name: mainnet
+            rpc_url: https://soroban-rpc.mainnet.stellar.org
+    steps:
+      - uses: actions/checkout@v4
+      - name: Canary (${{ matrix.name }})
+        env:
+          SOROBAN_RPC_URL: ${{ matrix.rpc_url }}
+        run: |
+          bash scripts/canary/public_endpoints.sh
+

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ Shared validation currently enforces:
 - Wasm target: `rustup target add wasm32-unknown-unknown`
 - Soroban CLI (`cargo install --locked soroban-cli`)
 
+### Bootstrap (recommended)
+
+To validate (and optionally install) the toolchain in a rerunnable way:
+
+```sh
+./scripts/bootstrap.sh --install
+```
+
 ### Local setup
 
 Clone the repository and format the workspace:
@@ -206,6 +214,11 @@ TMPDIR=/tmp cargo test --workspace
 
 `TMPDIR=/tmp` is used here because the current sandbox environment does not allow
 Rust to create temporary build directories in the default macOS temp location.
+
+## Operator docs
+
+- Testnet operator runbook: `docs/testnet-operator-runbook.md`
+- Bridge payload + resolver schema docs: `docs/schemas.md`
 
 ## Roadmap
 

--- a/contracts/resolver/src/lib.rs
+++ b/contracts/resolver/src/lib.rs
@@ -134,9 +134,13 @@ impl ResolverContract {
             .get(&DataKey::Primary(address.clone()))
             .or_else(|| env.storage().persistent().get(&DataKey::Reverse(address)))
     }
-}
 
-    pub fn transfer_record_owner(env: Env, name: String, caller: Address, new_owner: Address) -> Result<(), ResolverError> {
+    pub fn transfer_record_owner(
+        env: Env,
+        name: String,
+        caller: Address,
+        new_owner: Address,
+    ) -> Result<(), ResolverError> {
         let mut record = get_record(&env, &name)?;
         if record.owner != caller {
             return Err(ResolverError::Unauthorized);

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -1,0 +1,66 @@
+# Bridge Payload & Resolver Record Schemas
+
+This document describes the data shapes exposed by the current contracts so integrators can build
+against a stable surface without reading contract source.
+
+## Bridge
+
+### `BridgeRoute`
+
+Stored under a `Route(<chain>)` persistent key in the Bridge contract.
+
+Fields:
+
+- `destination_chain` (string): Canonical chain identifier (e.g. `base`, `ethereum`, `arbitrum`).
+- `destination_resolver` (string): Destination resolver identifier for the target chain.
+- `gateway` (string): Gateway identifier used by the destination system.
+
+### `build_message(name, chain) -> string`
+
+Returns a JSON string shaped like:
+
+```json
+{
+  "type": "xlm-ns-resolution",
+  "name": "<fqdn>",
+  "destination_chain": "<chain>",
+  "resolver": "<destination_resolver>"
+}
+```
+
+Notes:
+
+- `name` must be a fully-qualified `.xlm` name (validated on-chain).
+- `chain` must be a valid chain identifier (validated on-chain) and must have been registered.
+- The returned message is deterministic for a given `(name, route)` pair.
+
+## Resolver
+
+### `ResolutionRecord`
+
+Stored under a `Forward(<name>)` persistent key in the Resolver contract.
+
+Fields:
+
+- `owner` (Address): Account authorized to mutate the record.
+- `address` (string): Resolved target address for forward resolution.
+- `text_records` (map<string, string>): Bounded set of text records (max `MAX_TEXT_RECORDS`).
+- `updated_at` (u64): Unix timestamp supplied by the caller on write.
+
+### Forward resolution
+
+- `resolve(name) -> Option<ResolutionRecord>`
+- Storage key: `Forward(<name>)`
+
+### Reverse resolution
+
+- `reverse(address) -> Option<string>`
+- Storage keys:
+  - `Primary(<address>)` (preferred when set)
+  - `Reverse(<address>)` (fallback)
+
+### Text records
+
+- `set_text_record(name, caller, key, value, now_unix) -> Result<(), ResolverError>`
+- Writes mutate the `text_records` map inside the `Forward(<name>)` record.
+

--- a/docs/testnet-operator-runbook.md
+++ b/docs/testnet-operator-runbook.md
@@ -1,0 +1,88 @@
+# Testnet Operator Runbook (Deploy → Register → Resolve)
+
+This runbook is focused on an operator or integrator running the end-to-end flow on **Stellar testnet**:
+
+1. Configure RPC + network passphrase.
+2. Deploy contracts (or point at existing deployments).
+3. Register a name.
+4. Resolve it forward and reverse.
+5. Set text records.
+
+## Prerequisites
+
+- `scripts/bootstrap.sh --install` (or ensure tooling is installed)
+- A funded testnet account for any write operations (registration, transfers, text-record writes).
+
+## Environment
+
+The CLI reads configuration from env vars (with testnet defaults):
+
+- `SOROBAN_RPC_URL` (default: `https://soroban-testnet.stellar.org`)
+- `SOROBAN_NETWORK_PASSPHRASE` (default: `Test SDF Network ; September 2015`)
+- `REGISTRY_CONTRACT_ID` (required unless you are using a build that bakes defaults)
+- `RESOLVER_CONTRACT_ID` (required unless you are using a build that bakes defaults)
+
+For signing, profiles are loaded from env vars:
+
+- `XLM_NS_SIGNER_<PROFILE>_PUBLIC`
+- `XLM_NS_SIGNER_<PROFILE>_SECRET`
+
+Example (replace values):
+
+```sh
+export XLM_NS_SIGNER_OPERATOR_PUBLIC="G..."
+export XLM_NS_SIGNER_OPERATOR_SECRET="S..."
+export REGISTRY_CONTRACT_ID="C..."
+export RESOLVER_CONTRACT_ID="C..."
+```
+
+## Deploy (testnet)
+
+If you already have contract IDs for testnet, you can skip deployment and set
+`REGISTRY_CONTRACT_ID` / `RESOLVER_CONTRACT_ID`.
+
+If you are deploying yourself, use the Soroban CLI for your environment and
+record the resulting contract IDs.
+
+## Register a name
+
+Build the CLI:
+
+```sh
+cargo build -p xlm-ns-cli
+```
+
+Register a name (example):
+
+```sh
+cargo run -p xlm-ns-cli -- register timmy.xlm "$XLM_NS_SIGNER_OPERATOR_PUBLIC" --signer operator
+```
+
+## Resolve a name
+
+Forward resolution:
+
+```sh
+cargo run -p xlm-ns-cli -- resolve timmy.xlm
+```
+
+Reverse lookup:
+
+```sh
+cargo run -p xlm-ns-cli -- reverse-lookup "$XLM_NS_SIGNER_OPERATOR_PUBLIC"
+```
+
+## Text records
+
+Set a text record:
+
+```sh
+cargo run -p xlm-ns-cli -- text set timmy.xlm url "https://example.com" --signer operator
+```
+
+Read a text record:
+
+```sh
+cargo run -p xlm-ns-cli -- text get timmy.xlm url
+```
+

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/bootstrap.sh [--install]
+
+Checks the local toolchain needed for this repo. With --install, it attempts to
+install missing pieces in a safe, rerunnable way.
+
+What it checks:
+  - rustup / cargo (Rust toolchain)
+  - wasm32 target
+  - soroban CLI
+EOF
+}
+
+INSTALL=false
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if [[ "${1:-}" == "--install" ]]; then
+  INSTALL=true
+fi
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+header() {
+  printf '\n== %s ==\n' "$1"
+}
+
+header "Rust"
+if need_cmd rustup; then
+  rustup --version
+else
+  echo "Missing: rustup"
+  echo "Install: https://rustup.rs/"
+  exit 1
+fi
+
+if need_cmd cargo; then
+  cargo --version
+else
+  echo "Missing: cargo (should come with rustup)"
+  exit 1
+fi
+
+header "Wasm target"
+if rustup target list --installed | grep -q '^wasm32-unknown-unknown$'; then
+  echo "wasm32-unknown-unknown: installed"
+else
+  echo "wasm32-unknown-unknown: missing"
+  if [[ "$INSTALL" == "true" ]]; then
+    rustup target add wasm32-unknown-unknown
+  else
+    echo "Install with: rustup target add wasm32-unknown-unknown"
+  fi
+fi
+
+header "Soroban CLI"
+if need_cmd soroban; then
+  soroban --version || true
+else
+  echo "Missing: soroban"
+  if [[ "$INSTALL" == "true" ]]; then
+    cargo install --locked soroban-cli
+  else
+    echo "Install with: cargo install --locked soroban-cli"
+  fi
+fi
+
+header "Done"
+echo "Bootstrap checks complete."
+

--- a/scripts/canary/public_endpoints.sh
+++ b/scripts/canary/public_endpoints.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RPC_URL="${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}"
+
+jsonrpc() {
+  local method="$1"
+  curl -fsS -H 'content-type: application/json' \
+    --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"${method}\"}" \
+    "${RPC_URL}"
+}
+
+echo "Canary: RPC health check"
+echo "  SOROBAN_RPC_URL=${RPC_URL}"
+
+# Non-destructive endpoint checks to catch integration drift early.
+jsonrpc getHealth >/dev/null
+jsonrpc getNetwork >/dev/null
+
+echo "OK"
+


### PR DESCRIPTION
Closes #191
Closes #195
Closes #197
Closes #198

- Adds a rerunnable local bootstrap script.
- Documents testnet operator flow and schema shapes.
- Adds a nightly scheduled canary workflow against public endpoints.