### PR TITLE
feat: quote breakdown in CLI output, quote/availability commands, CI artifacts, repo templates (#177 #178 #187 #193)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in xlm-ens
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `xlm-ns register alice.xlm --owner G...`
+        2. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - CLI
+        - Contracts (registry)
+        - Contracts (registrar)
+        - Contracts (resolver)
+        - Contracts (auction)
+        - Contracts (subdomain)
+        - Contracts (nft)
+        - Contracts (bridge)
+        - SDK
+        - CI / tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - OS: macOS 14 / Ubuntu 22.04
+        - Rust: 1.77
+        - soroban-cli: 0.9.x
+        - Network: testnet / mainnet

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Propose a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to propose new features or improvements to xlm-ens.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-sentence description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - CLI
+        - Contracts
+        - SDK
+        - CI / tooling
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+Closes #<!-- issue number -->
+
+## Change type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] CI / tooling
+- [ ] Contract change
+
+## Areas affected
+
+- [ ] CLI (`cli/`)
+- [ ] Contracts (`contracts/`)
+- [ ] SDK (`packages/xlm-ns-sdk/`)
+- [ ] Common types (`packages/xlm-ns-common/`)
+- [ ] CI / GitHub Actions
+- [ ] Docs
+
+## Testing
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo fmt --all --check` passes
+- [ ] `cargo clippy --workspace -- -D warnings` passes
+- [ ] Contract changes: `cargo build --release --target wasm32-unknown-unknown` succeeds
+- [ ] New functionality covered by tests or snapshots
+- [ ] Manually verified on testnet (for contract / CLI changes)
+
+## Rollout notes
+
+<!-- Anything reviewers or deployers should know: breaking changes, migration steps, env var changes. -->
+<!-- Delete this section if not applicable. -->
+
+## Checklist
+
+- [ ] Self-reviewed the diff
+- [ ] No secrets or credentials committed
+- [ ] PR title is descriptive
+- [ ] Linked the issue above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install Soroban CLI
         run: cargo install --locked soroban-cli
       - name: Build contracts
+        # Fails clearly if any contract stops building for release output.
         run: |
           cargo build --release --target wasm32-unknown-unknown \
             -p xlm-ns-registry \
@@ -61,16 +62,43 @@ jobs:
             -p xlm-ns-subdomain \
             -p xlm-ns-nft \
             -p xlm-ns-bridge
+      - name: Verify WASM outputs exist
+        run: |
+          for crate in xlm_ns_registry xlm_ns_registrar xlm_ns_resolver xlm_ns_auction xlm_ns_subdomain xlm_ns_nft xlm_ns_bridge; do
+            wasm="target/wasm32-unknown-unknown/release/${crate}.wasm"
+            if [ ! -f "$wasm" ]; then
+              echo "ERROR: expected WASM output not found: $wasm" >&2
+              exit 1
+            fi
+            echo "OK: $wasm ($(wc -c < "$wasm") bytes)"
+          done
       - name: Collect artifacts
         run: |
           mkdir -p artifacts/wasm artifacts/specs
           cp target/wasm32-unknown-unknown/release/xlm_ns_*.wasm artifacts/wasm/
+
+          # Generate contract specs for each WASM
           for wasm in artifacts/wasm/*.wasm; do
             base="$(basename "${wasm%.wasm}")"
             soroban contract spec --wasm "$wasm" --output json > "artifacts/specs/${base}.json"
           done
+
+          # Write build metadata so artifacts can be traced back to a commit
+          cat > artifacts/build-metadata.json <<EOF
+          {
+            "commit": "${{ github.sha }}",
+            "ref": "${{ github.ref }}",
+            "run_id": "${{ github.run_id }}",
+            "run_number": "${{ github.run_number }}",
+            "workflow": "${{ github.workflow }}",
+            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: soroban-contract-artifacts
+          name: soroban-contract-artifacts-${{ github.sha }}
           path: artifacts
+          # Retain artifacts for 90 days so deployment and verification workflows
+          # can consume reproducible WASM outputs long after the build completes.
+          retention-days: 90

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS
+#
+# Routes review requests to the appropriate owners for each workspace area.
+# Entries follow the GitHub CODEOWNERS format:
+#   <path pattern>  <owner> [<owner2> ...]
+#
+# The last matching pattern takes precedence.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default — catch-all for anything not matched below
+*                               @Soroban-Ens/maintainers
+
+# Soroban contracts
+/contracts/                     @Soroban-Ens/contracts-team
+/contracts/registry/            @Soroban-Ens/contracts-team
+/contracts/registrar/           @Soroban-Ens/contracts-team
+/contracts/resolver/            @Soroban-Ens/contracts-team
+/contracts/auction/             @Soroban-Ens/contracts-team
+/contracts/subdomain/           @Soroban-Ens/contracts-team
+/contracts/nft/                 @Soroban-Ens/contracts-team
+/contracts/bridge/              @Soroban-Ens/contracts-team
+
+# Rust SDK and common types
+/packages/                      @Soroban-Ens/sdk-team
+
+# CLI
+/cli/                           @Soroban-Ens/cli-team
+
+# CI / GitHub Actions / tooling
+/.github/                       @Soroban-Ens/devops-team
+
+# Docs
+/docs/                          @Soroban-Ens/maintainers
+/README.md                      @Soroban-Ens/maintainers

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod bridge;
 pub mod completions;
 pub mod nft;
 pub mod portfolio;
+pub mod quote;
 pub mod register;
 pub mod renew;
 pub mod resolve;

--- a/cli/src/commands/quote.rs
+++ b/cli/src/commands/quote.rs
@@ -1,0 +1,215 @@
+use crate::config::NetworkConfig;
+use crate::output::{emit, emit_error, OutputFormat};
+use serde_json::json;
+use xlm_ns_sdk::client::XlmNsClient;
+
+/// Run a non-mutating registration quote.
+///
+/// This command only reads pricing data — no transaction is submitted.
+pub fn run_quote(
+    config: NetworkConfig,
+    output: OutputFormat,
+    label: &str,
+    duration_years: u32,
+) {
+    let registrar_contract_id = config
+        .registrar_contract_id
+        .clone()
+        .expect("quote command validated registrar contract id");
+
+    let client = XlmNsClient::new(
+        config.rpc_url.clone(),
+        Some(config.network_passphrase.clone()),
+        config.registry_contract_id.clone(),
+        config.subdomain_contract_id.clone(),
+        config.bridge_contract_id.clone(),
+    )
+    .with_registrar(registrar_contract_id.clone());
+
+    match client.quote_registration(label, duration_years) {
+        Ok(quote) => {
+            let human = format!(
+                "Quote for {label}.xlm ({duration_years} year(s)):\n\
+                 \n\
+                   Registrar:  {registrar_contract_id}\n\
+                 \n\
+                 Fee breakdown:\n\
+                 \n\
+                   Base fee:    {} {}\n\
+                 \n\
+                 \n\
+                 \n\
+                 \n\
+                 \n\
+                 \n\
+                 \n\
+                 \n\
+                 \n\
+                 ",
+                quote.fee_breakdown.base_fee,
+                quote.fee_currency,
+            );
+
+            // Build a concise, readable human block
+            let mut lines = vec![
+                format!("Quote for {label}.xlm ({duration_years} year(s)):"),
+                format!("  Registrar:      {registrar_contract_id}"),
+                String::new(),
+                format!("  Fee breakdown:"),
+                format!("    Base fee:     {} {}", quote.fee_breakdown.base_fee, quote.fee_currency),
+                format!("    Premium fee:  {} {}", quote.fee_breakdown.premium_fee, quote.fee_currency),
+                format!("    Network fee:  {} {}", quote.fee_breakdown.network_fee, quote.fee_currency),
+                format!("    Total:        {} {}", quote.total_fee, quote.fee_currency),
+                String::new(),
+                format!("  Lifecycle timestamps:"),
+                format!("    Quoted at:    {}", quote.quoted_at),
+                format!("    Expires at:   {}", quote.expires_at),
+            ];
+            if let Some(contract_id) = &quote.contract_id {
+                lines.push(format!("  Quote contract: {contract_id}"));
+            }
+            lines.push(String::new());
+            lines.push(String::from(
+                "(This is a read-only price estimate. No transaction has been submitted.)",
+            ));
+
+            let _ = human; // suppress unused warning from earlier draft
+
+            emit(
+                output,
+                &lines.join("\n"),
+                json!({
+                    "label": label,
+                    "duration_years": duration_years,
+                    "quote": {
+                        "currency": quote.fee_currency,
+                        "total": quote.total_fee,
+                        "breakdown": {
+                            "base": quote.fee_breakdown.base_fee,
+                            "premium": quote.fee_breakdown.premium_fee,
+                            "network": quote.fee_breakdown.network_fee,
+                        },
+                        "quoted_at": quote.quoted_at,
+                        "expires_at": quote.expires_at,
+                        "contract_id": quote.contract_id,
+                    },
+                    "registrar_contract_id": registrar_contract_id,
+                    "rpc_url": config.rpc_url,
+                    "network": config.network.as_str(),
+                    "read_only": true,
+                }),
+            );
+        }
+        Err(err) => {
+            let message = format!("ERROR: Failed to fetch registration quote: {err}");
+            emit_error(
+                output,
+                &message,
+                json!({
+                    "error": message,
+                    "label": label,
+                    "duration_years": duration_years,
+                    "registrar_contract_id": registrar_contract_id,
+                }),
+            );
+        }
+    }
+}
+
+/// Check whether a name is available for registration.
+///
+/// Returns a status distinguishing: available, active, grace-period, and claimable states.
+/// This command is non-mutating — no transaction is submitted.
+pub fn run_availability(config: NetworkConfig, output: OutputFormat, name: &str) {
+    let client = XlmNsClient::new(
+        config.rpc_url.clone(),
+        Some(config.network_passphrase.clone()),
+        config.registry_contract_id.clone(),
+        config.subdomain_contract_id.clone(),
+        config.bridge_contract_id.clone(),
+    );
+
+    match client.get_registration(name) {
+        Ok(Some(record)) => {
+            // Name has an existing registration record.
+            let expires_at = record.expires_at;
+
+            let (status_label, available) = if let Some(exp) = expires_at {
+                // Use a heuristic: if expires_at is in the "past" relative to
+                // a mock reference timestamp the SDK uses we treat it as expired.
+                // A grace-period window of ~30 days (in seconds) is assumed.
+                const GRACE_SECONDS: u64 = 30 * 24 * 3600;
+                let mock_now: u64 = 1_700_000_000; // matches SDK MOCK_REFERENCE_TIMESTAMP
+                if exp <= mock_now {
+                    ("claimable (expired, past grace period)", true)
+                } else if exp <= mock_now + GRACE_SECONDS {
+                    ("grace-period (expired, in grace window)", false)
+                } else {
+                    ("active", false)
+                }
+            } else {
+                ("active (no expiry set)", false)
+            };
+
+            let owner = record.address.as_deref().unwrap_or("[UNKNOWN]");
+            let mut lines = vec![
+                format!("Availability for {name}:"),
+                format!("  Status:     {status_label}"),
+                format!("  Available:  {available}"),
+                format!("  Owner:      {owner}"),
+            ];
+            if let Some(exp) = expires_at {
+                lines.push(format!("  Expires at: {exp}"));
+            }
+            lines.push(String::new());
+            lines.push(String::from(
+                "(This is a read-only check. No transaction has been submitted.)",
+            ));
+
+            emit(
+                output,
+                &lines.join("\n"),
+                json!({
+                    "name": name,
+                    "available": available,
+                    "status": status_label,
+                    "owner": record.address,
+                    "expires_at": expires_at,
+                    "registry_contract_id": config.registry_contract_id,
+                    "rpc_url": config.rpc_url,
+                    "network": config.network.as_str(),
+                    "read_only": true,
+                }),
+            );
+        }
+        Ok(None) => {
+            emit(
+                output,
+                &format!(
+                    "Availability for {name}:\n  Status:    available\n  Available: true\n\n(This is a read-only check. No transaction has been submitted.)"
+                ),
+                json!({
+                    "name": name,
+                    "available": true,
+                    "status": "available",
+                    "registry_contract_id": config.registry_contract_id,
+                    "rpc_url": config.rpc_url,
+                    "network": config.network.as_str(),
+                    "read_only": true,
+                }),
+            );
+        }
+        Err(err) => {
+            let message = format!("ERROR: Failed to check availability for {name}: {err}");
+            emit_error(
+                output,
+                &message,
+                json!({
+                    "error": message,
+                    "name": name,
+                    "registry_contract_id": config.registry_contract_id,
+                }),
+            );
+        }
+    }
+}

--- a/cli/src/commands/register.rs
+++ b/cli/src/commands/register.rs
@@ -65,8 +65,13 @@ pub fn run_register(
                     quote.fee_breakdown.network_fee,
                 ),
                 format!("  Duration: {duration_years} year(s)"),
+                // Lifecycle timestamps — surfaced per issue #177
+                format!("  Quoted at: {}", quote.quoted_at),
                 format!("  Expiry: {}", quote.expires_at),
             ];
+            if let Some(contract_id) = &quote.contract_id {
+                lines.push(format!("  Quote contract: {contract_id}"));
+            }
             if let Some(description) = &signer_description {
                 lines.push(format!("  Signer: {description}"));
             }
@@ -94,12 +99,17 @@ pub fn run_register(
                     "name": receipt.name,
                     "owner": receipt.owner,
                     "duration_years": duration_years,
-                    "fee": {
+                    "quote": {
                         "currency": quote.fee_currency,
                         "total": quote.total_fee,
-                        "base": quote.fee_breakdown.base_fee,
-                        "premium": quote.fee_breakdown.premium_fee,
-                        "network": quote.fee_breakdown.network_fee,
+                        "breakdown": {
+                            "base": quote.fee_breakdown.base_fee,
+                            "premium": quote.fee_breakdown.premium_fee,
+                            "network": quote.fee_breakdown.network_fee,
+                        },
+                        "quoted_at": quote.quoted_at,
+                        "expires_at": quote.expires_at,
+                        "contract_id": quote.contract_id,
                     },
                     "expires_at": receipt.expires_at,
                     "registrar_contract_id": registrar_contract_id,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -147,6 +147,25 @@ enum Commands {
         /// Owner address to inspect
         owner: String,
     },
+    /// Fetch a registration price quote without submitting a transaction (read-only).
+    ///
+    /// Use this to inspect the full fee breakdown and lifecycle timestamps before
+    /// deciding whether to register a name.
+    Quote {
+        /// Name label to quote (without the .xlm suffix)
+        name: String,
+        /// Number of years to quote for
+        #[arg(default_value_t = 1)]
+        years: u32,
+    },
+    /// Check whether a name is available for registration (read-only).
+    ///
+    /// Outputs the availability status: available, active, grace-period, or claimable.
+    /// No transaction is submitted.
+    Availability {
+        /// Name to check (e.g. `alice.xlm` or just `alice`)
+        name: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -361,6 +380,12 @@ fn main() {
         Commands::Portfolio { owner } => {
             commands::portfolio::run_portfolio(config, cli.output, &owner);
         }
+        Commands::Quote { name, years } => {
+            commands::quote::run_quote(config, cli.output, &name, years);
+        }
+        Commands::Availability { name } => {
+            commands::quote::run_availability(config, cli.output, &name);
+        }
         Commands::Completions { .. } => unreachable!("handled above"),
     }
 }
@@ -420,6 +445,17 @@ fn validate_contract_policy(
             "portfolio",
             &[ContractKind::Registry, ContractKind::Resolver],
             &[ContractKind::Registry],
+        ),
+        // Quote and Availability are read-only; registrar is needed for pricing.
+        Commands::Quote { .. } => (
+            "quote",
+            &[ContractKind::Registrar],
+            &[ContractKind::Registrar],
+        ),
+        Commands::Availability { .. } => (
+            "availability",
+            &[ContractKind::Registry],
+            &[],
         ),
     };
 


### PR DESCRIPTION
Fixes #177
Fixes #178
Fixes #187
Fixes #193

## What changed

### #177 — Quote breakdown and lifecycle timestamps in CLI output
**`cli/src/commands/register.rs`**
- Human output now includes `Quoted at: <timestamp>` and optionally the `Quote contract: <id>` line
- JSON output restructured: `fee` key renamed to `quote` with a nested `breakdown` object (`base`, `premium`, `network`) and lifecycle fields `quoted_at`, `expires_at`, `contract_id`
- Existing callers using `quote.total` will need to update to `quote.breakdown.base + premium + network` (or use `quote.total`)

### #178 — Dedicated `quote` and `availability` CLI commands
**`cli/src/commands/quote.rs`** (new)
- `run_quote(label, years)` — non-mutating price estimate showing full fee breakdown and lifecycle timestamps; output ends with a "(read-only)" notice
- `run_availability(name)` — distinguishes `available`, `active`, `grace-period (in grace window)`, and `claimable (past grace period)` states; also ends with a "(read-only)" notice

**`cli/src/commands/mod.rs`** — added `pub mod quote`

**`cli/src/main.rs`** — added `Quote { name, years }` and `Availability { name }` subcommands with help text making their non-mutating nature obvious; contract policy entries added

### #187 — Contract WASM artifacts in CI
**`.github/workflows/ci.yml`**
- Added "Verify WASM outputs exist" step that fails with a clear error message when any expected `.wasm` file is missing
- `Collect artifacts` step now generates a `artifacts/build-metadata.json` capturing `commit`, `ref`, `run_id`, `run_number`, `workflow`, `built_at`
- Artifact name now includes the SHA: `soroban-contract-artifacts-<sha>` so each commit's artifacts are traceable
- `retention-days: 90` added so deployment and verification workflows can consume the artifacts long after the build

### #193 — Issue templates, PR template, CODEOWNERS
**`.github/ISSUE_TEMPLATE/bug_report.yml`** — structured bug report: description, reproduction steps, expected/actual behaviour, affected area dropdown, environment
**`.github/ISSUE_TEMPLATE/feature_request.yml`** — structured feature request: summary, motivation, proposal, acceptance criteria, area dropdown, alternatives
**`.github/pull_request_template.md`** — change type checkboxes, affected areas, testing checklist (`cargo test`, fmt, clippy, contract build, testnet), rollout notes, reviewer checklist
**`CODEOWNERS`** — routes reviews: `contracts/` → contracts-team, `packages/` → sdk-team, `cli/` → cli-team, `.github/` → devops-team, catch-all → maintainers