### PR TITLE
chore: add release automation, dep updates, contributor guide, and se…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+
+updates:
+  # ── Cargo (Rust workspace) ──────────────────────────────────────────────────
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: UTC
+    # Group all non-breaking updates into one PR to keep noise low.
+    # Security updates are always opened individually so they can be merged fast.
+    groups:
+      soroban:
+        patterns:
+          - "soroban-*"
+          - "stellar-*"
+        update-types:
+          - minor
+          - patch
+      serde:
+        patterns:
+          - "serde"
+          - "serde_*"
+        update-types:
+          - minor
+          - patch
+      clap:
+        patterns:
+          - "clap"
+          - "clap_*"
+        update-types:
+          - minor
+          - patch
+      misc-patch:
+        update-types:
+          - patch
+    # Open at most 5 Cargo PRs at a time to prevent review pile-up.
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      # Major version bumps require deliberate review — do not auto-propose.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: UTC
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,322 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version tag to release (e.g. v0.2.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run — build artifacts but do not publish"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+env:
+  CARGO_TERM_COLOR: always
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+jobs:
+  # ── Validation ─────────────────────────────────────────────────────────────
+  validate:
+    name: Validate tag matches workspace version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Parse version from tag
+        id: parse
+        run: |
+          TAG="${{ env.RELEASE_TAG }}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Cargo.toml version matches tag
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Cargo.toml version ($CARGO_VERSION) does not match release tag ($TAG_VERSION)"
+            echo "Update [workspace.package] version in Cargo.toml to $TAG_VERSION before tagging."
+            exit 1
+          fi
+          echo "Version check passed: $CARGO_VERSION"
+
+  # ── Tests ───────────────────────────────────────────────────────────────────
+  test:
+    name: Workspace tests
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Rust
+        run: rustup update stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
+      - name: Run tests
+        run: cargo test --workspace
+
+  # ── CLI binary matrix build ─────────────────────────────────────────────────
+  build-cli:
+    name: Build CLI — ${{ matrix.target }}
+    needs: [validate, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: tar.gz
+            cross: true
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            archive: zip
+            binary_suffix: .exe
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Rust
+        run: rustup update stable && rustup target add ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross (for cross-compiled targets)
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
+      - name: Build CLI binary
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} -p xlm-ns-cli
+          else
+            cargo build --release --target ${{ matrix.target }} -p xlm-ns-cli
+          fi
+        shell: bash
+
+      - name: Package artifact (tar.gz)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          BIN="target/${{ matrix.target }}/release/xlm-ns-cli${{ matrix.binary_suffix }}"
+          ARCHIVE="xlm-ns-cli-${{ needs.validate.outputs.version }}-${{ matrix.target }}.tar.gz"
+          tar -czf "$ARCHIVE" -C "$(dirname $BIN)" "$(basename $BIN)"
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Package artifact (zip)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $bin = "target/${{ matrix.target }}/release/xlm-ns-cli${{ matrix.binary_suffix }}"
+          $archive = "xlm-ns-cli-${{ needs.validate.outputs.version }}-${{ matrix.target }}.zip"
+          Compress-Archive -Path $bin -DestinationPath $archive
+          "ARCHIVE=${archive}" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  # ── Contract WASM artifacts ─────────────────────────────────────────────────
+  build-contracts:
+    name: Build contract artifacts
+    needs: [validate, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Rust
+        run: rustup update stable && rustup target add wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
+      - name: Install Soroban CLI
+        run: cargo install --locked soroban-cli
+
+      - name: Build contracts
+        run: |
+          cargo build --release --target wasm32-unknown-unknown \
+            -p xlm-ns-registry \
+            -p xlm-ns-registrar \
+            -p xlm-ns-resolver \
+            -p xlm-ns-auction \
+            -p xlm-ns-subdomain \
+            -p xlm-ns-nft \
+            -p xlm-ns-bridge
+
+      - name: Collect WASM and specs
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          mkdir -p release-contracts/wasm release-contracts/specs
+          cp target/wasm32-unknown-unknown/release/xlm_ns_*.wasm release-contracts/wasm/
+          for wasm in release-contracts/wasm/*.wasm; do
+            base="$(basename "${wasm%.wasm}")"
+            soroban contract spec --wasm "$wasm" --output json > "release-contracts/specs/${base}.json"
+          done
+          tar -czf "xlm-ns-contracts-${VERSION}.tar.gz" release-contracts/
+
+      - name: Upload contract artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts
+          path: xlm-ns-contracts-${{ needs.validate.outputs.version }}.tar.gz
+
+  # ── GitHub Release ──────────────────────────────────────────────────────────
+  publish-release:
+    name: Publish GitHub Release
+    needs: [validate, build-cli, build-contracts]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+
+      - name: Flatten dist directory
+        run: find dist/ -type f | xargs -I{} mv {} dist/ 2>/dev/null || true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum *.tar.gz *.zip 2>/dev/null | tee SHA256SUMS.txt || sha256sum *.tar.gz | tee SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        if: inputs.dry_run != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: xlm-ns ${{ env.RELEASE_TAG }}
+          body: |
+            ## xlm-ns ${{ env.RELEASE_TAG }}
+
+            ### CLI Binaries
+
+            Pre-built binaries are attached below for Linux (x86_64, aarch64), macOS (x86_64, Apple Silicon), and Windows (x86_64).
+
+            **Verify your download:**
+            ```
+            sha256sum -c SHA256SUMS.txt
+            ```
+
+            ### Contract Artifacts
+
+            `xlm-ns-contracts-*.tar.gz` contains the compiled `.wasm` files and JSON contract specs for all seven Soroban contracts.
+
+            ### Install from crates.io
+
+            ```
+            cargo install xlm-ns-cli
+            ```
+
+            ### Changelog
+
+            See [CHANGELOG.md](CHANGELOG.md) for details on what changed in this release.
+          files: dist/*
+          fail_on_unmatched_files: false
+
+      - name: Dry-run summary
+        if: inputs.dry_run == 'true'
+        run: |
+          echo "DRY RUN — the following files would be attached to release ${{ env.RELEASE_TAG }}:"
+          ls -lh dist/
+
+  # ── Crate publish (human checkpoint required) ──────────────────────────────
+  publish-crates:
+    name: Publish crates to crates.io
+    needs: publish-release
+    runs-on: ubuntu-latest
+    environment: crates-io   # requires manual approval in GitHub Environments
+    if: inputs.dry_run != 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Rust
+        run: rustup update stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
+      # Publish in dependency order: common → sdk → contracts → cli
+      # --no-verify skips re-running tests (already done in the test job).
+      # Each crate is published separately so partial failures are visible.
+      - name: Publish xlm-ns-common
+        run: cargo publish -p xlm-ns-common --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish xlm-ns-sdk
+        run: cargo publish -p xlm-ns-sdk --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish contracts
+        run: |
+          for pkg in xlm-ns-registry xlm-ns-registrar xlm-ns-resolver xlm-ns-auction xlm-ns-subdomain xlm-ns-nft xlm-ns-bridge; do
+            echo "Publishing $pkg…"
+            cargo publish -p "$pkg" --no-verify
+            # crates.io enforces a short delay between publishes
+            sleep 20
+          done
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish xlm-ns-cli
+        run: cargo publish -p xlm-ns-cli --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,126 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues by emailing:
+
+**security@xlm-ns.org**
+
+Include as much of the following as you can:
+
+- A clear description of the vulnerability and its potential impact.
+- The affected component(s): contract name, CLI command, SDK method, or
+  configuration path.
+- Steps to reproduce or a minimal proof-of-concept.
+- Any mitigating factors you are aware of.
+
+You will receive an acknowledgement within **2 business days**.
+
+If you do not receive a response within 4 business days, follow up at the same
+address with "REMINDER" in the subject line.
+
+---
+
+## Disclosure process
+
+| Step | Owner | Target timeline |
+|------|-------|----------------|
+| Acknowledgement | Maintainers | 2 business days |
+| Initial triage and severity rating | Maintainers | 5 business days |
+| Reproduce and confirm | Maintainers | 10 business days |
+| Patch development | Maintainers + reporter (optional) | Depends on severity |
+| Coordinated disclosure | Both parties agree on date | ≥ 7 days after patch ships |
+| Public CVE or advisory | Maintainers | Same day as disclosure |
+
+We follow **coordinated disclosure**.  We will not disclose a vulnerability
+publicly until a patch is available *and* the reporter has had a chance to
+review it, unless the vulnerability is already being actively exploited.
+
+We ask reporters to observe the same embargo until the coordinated date.
+
+---
+
+## Severity rating
+
+We use a simplified four-level scale:
+
+| Severity | Description | Example |
+|----------|-------------|---------|
+| **Critical** | Arbitrary fund theft or unauthorized ownership transfer on mainnet | Logic error allowing any caller to transfer a name without owner auth |
+| **High** | Denial-of-service or permanent data corruption | Overflow causing a name to expire immediately on registration |
+| **Medium** | Information leak or non-fund-critical contract misbehaviour | Resolver returns stale records outside the TTL window |
+| **Low** | Minor issues with limited real-world impact | CLI leaks the network passphrase in a debug log |
+
+Critical and High findings are patched and released as soon as possible.
+Medium and Low findings are batched into the next scheduled release.
+
+---
+
+## Scope
+
+### In scope
+
+- All Soroban contracts under `contracts/` deployed to Stellar testnet or mainnet.
+- The `xlm-ns-cli` binary and all subcommands.
+- The `xlm-ns-sdk` and `xlm-ns-common` crates when used as library dependencies.
+- Configuration parsing and signer key handling in the CLI.
+
+### Out of scope
+
+- Third-party infrastructure (Stellar core, Soroban RPC nodes, Axelar gateway).
+- Vulnerabilities that require the attacker to already control the victim's
+  Stellar private key.
+- Issues in dependencies that are already publicly disclosed — report those
+  upstream and open a non-security PR here to bump the version.
+- Social-engineering attacks against maintainers.
+
+---
+
+## Security assumptions and threat model
+
+The high-level trust boundaries for xlm-ns are documented in the README under
+**Security and Threat Model**.  Key assumptions relevant to vulnerability reports:
+
+1. **No privileged recovery path** — the registry and registrar have no admin
+   override.  Ownership changes only through the normal expiry/grace/claimable
+   flow or explicit owner-initiated transfer.  A report claiming that "the admin
+   cannot reclaim a stolen name" is by design, not a bug.
+
+2. **Auth is enforced by Soroban** — every mutation requires
+   `Address::require_auth()`.  A finding that bypasses this is Critical.
+
+3. **Signer secrets are never stored in structs** — the CLI reads secrets from
+   environment variables at signing time only.  A finding that causes secrets to
+   be written to disk, logs, or network is High.
+
+4. **The SDK is currently mock-based** — it does not make live RPC calls.
+   Security findings against the mock layer are Low unless they affect the
+   real-client path when it ships.
+
+---
+
+## Preferred languages and tools
+
+We can receive reports in English.  PoC code in Rust, shell, or Python is
+preferred.
+
+---
+
+## Recognition
+
+We do not currently run a paid bug-bounty programme.  Reporters of confirmed
+High or Critical vulnerabilities will be credited in the release notes and
+security advisory (with their consent) and offered a spot on the project's
+acknowledgements page.
+
+---
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest on `main` | Yes |
+| Tagged releases | Current + previous minor only |
+| Older releases | No — please upgrade |

--- a/docs/contributing-contracts.md
+++ b/docs/contributing-contracts.md
@@ -1,0 +1,228 @@
+# Contributing: Contract Specs, Snapshots, and Integration Tests
+
+This guide covers the parts of the xlm-ns workspace that require extra care when
+you change contracts: generated specs, snapshot test output, and multi-contract
+integration flows.  Read this before opening a PR that touches any file under
+`contracts/`.
+
+---
+
+## Table of contents
+
+1. [Contract specs](#1-contract-specs)
+2. [Snapshot tests](#2-snapshot-tests)
+3. [Integration tests](#3-integration-tests)
+4. [Required local commands](#4-required-local-commands)
+5. [CI expectations](#5-ci-expectations)
+
+---
+
+## 1. Contract specs
+
+### What they are
+
+Each Soroban contract exposes a machine-readable ABI called a *contract spec*.
+The CI `artifacts` job (`.github/workflows/ci.yml`) builds every contract to
+`wasm32-unknown-unknown`, extracts the spec with `soroban contract spec`, and
+uploads the JSON files under `artifacts/specs/`.
+
+### When specs change
+
+A spec changes whenever you:
+
+- Add, remove, or rename a public `#[contractimpl]` function.
+- Change the type or arity of any function argument or return value.
+- Add, remove, or rename a `#[contracttype]` struct, enum, or error enum.
+- Change a `#[contracterror]` discriminant value.
+
+Removing or renaming anything that is already in a deployed spec is a **breaking
+change** — existing callers and the SDK client will break silently.  Prefer
+adding new functions over changing existing ones.
+
+### How to update specs intentionally
+
+```sh
+# 1. Build the contracts for the wasm target.
+cargo build --release --target wasm32-unknown-unknown \
+  -p xlm-ns-registry -p xlm-ns-registrar -p xlm-ns-resolver \
+  -p xlm-ns-auction  -p xlm-ns-subdomain -p xlm-ns-nft -p xlm-ns-bridge
+
+# 2. Regenerate the spec files.
+mkdir -p artifacts/specs
+for wasm in target/wasm32-unknown-unknown/release/xlm_ns_*.wasm; do
+  base="$(basename "${wasm%.wasm}")"
+  soroban contract spec --wasm "$wasm" --output json \
+    > "artifacts/specs/${base}.json"
+done
+```
+
+Commit the updated JSON files together with the Rust changes that caused them.
+A PR that modifies a contract function but does not update the corresponding
+spec file will fail review.
+
+---
+
+## 2. Snapshot tests
+
+### What they are
+
+Snapshot files live in `tests/test_snapshots/`.  Each file captures the
+serialized output of one integration-test scenario — typically the full
+`NameRecord` or resolution payload returned by a cross-contract flow.  Snapshots
+let reviewers see exactly what a change does to on-chain state without reading
+through assertions manually.
+
+### When snapshots change
+
+Snapshots must be updated whenever:
+
+- The shape of a `NameRecord`, `ResolutionRecord`, or any other serialized type
+  changes.
+- A cross-contract flow changes the values it writes (e.g. TTL defaults, grace
+  period durations, fee amounts).
+- You intentionally add a new snapshot test for a new scenario.
+
+A snapshot that no longer matches the actual output will cause `cargo test` to
+fail with a diff showing old vs. new.
+
+### How to update snapshots intentionally
+
+```sh
+# Re-run the integration tests in update mode.
+UPDATE_SNAPSHOTS=1 cargo test --test registrar_registry_test
+```
+
+Review the diff in `tests/test_snapshots/` before committing.  Never commit a
+snapshot update without understanding why the output changed.
+
+Snapshot filenames follow this convention:
+
+```
+<test_module_name>.<test_number>.json
+```
+
+e.g. `subdomain_flow_covers_controller_delegation_transfer_and_resolution.1.json`
+
+---
+
+## 3. Integration tests
+
+### Layout
+
+```
+tests/
+├── Cargo.toml                  — test crate manifest
+├── integration/                — one file per contract-pair or flow
+│   ├── registrar_registry_test.rs
+│   ├── registrar_test.rs
+│   ├── registry_test.rs
+│   ├── subdomain_test.rs
+│   ├── auction_test.rs
+│   └── bridge_test.rs
+├── fixtures/                   — shared test data (accounts, name seeds)
+│   └── accounts.json
+└── test_snapshots/             — serialized scenario outputs (see §2)
+```
+
+Each file under `integration/` maps to a `[[test]]` entry in `tests/Cargo.toml`
+and is compiled as its own test binary.  This means a build error in one file
+does not block other test targets.
+
+### Fixture conventions
+
+`fixtures/accounts.json` contains named Stellar account key-pairs for use in
+tests.  Add new fixtures there rather than hardcoding keys inline.  Keep the
+file sorted by key name.
+
+Do not use real secret keys in fixtures — use deterministically generated test
+keys only (`Address::generate(&env)` for Soroban unit tests; placeholder
+`G…` strings for CLI-level tests).
+
+### Writing a new integration test
+
+1. Create `tests/integration/<contract>_<scenario>_test.rs`.
+2. Add a `[[test]]` entry to `tests/Cargo.toml`:
+   ```toml
+   [[test]]
+   name = "<contract>_<scenario>_test"
+   path = "integration/<contract>_<scenario>_test.rs"
+   ```
+3. Use `Env::default()` from `soroban-sdk` with the `testutils` feature — do
+   not rely on a live network.
+4. Wire contracts together with `env.register(…)` and initialize via the client
+   (see `registrar_registry_test.rs` for the canonical pattern).
+5. Assert on both sides of every cross-contract invariant — if the registrar
+   writes to the registry, check *both* the registrar record and the registry
+   entry.
+
+### Invariants to verify in every cross-contract test
+
+| Invariant | Where to check |
+|-----------|---------------|
+| `expires_at` matches between registrar and registry | Both clients |
+| `grace_period_ends_at` matches | Both clients |
+| Ownership is consistent after transfer | Registry client |
+| Subdomain controller list is updated | Subdomain client |
+| Auction winner becomes name owner | Registry client |
+
+### Placeholder tests
+
+Files that have not yet been filled in use:
+
+```rust
+#[test]
+fn <name>_placeholder() {
+    assert!(true);
+}
+```
+
+When you implement a real scenario, replace the placeholder entirely — do not
+leave it alongside real tests.
+
+---
+
+## 4. Required local commands
+
+Run these before pushing any contract change:
+
+```sh
+# Format check (must pass CI)
+cargo fmt --all --check
+
+# Full workspace test (includes integration tests)
+cargo test --workspace
+
+# Build wasm artifacts and regenerate specs
+cargo build --release --target wasm32-unknown-unknown \
+  -p xlm-ns-registry -p xlm-ns-registrar -p xlm-ns-resolver \
+  -p xlm-ns-auction  -p xlm-ns-subdomain -p xlm-ns-nft -p xlm-ns-bridge
+
+mkdir -p artifacts/specs
+for wasm in target/wasm32-unknown-unknown/release/xlm_ns_*.wasm; do
+  base="$(basename "${wasm%.wasm}")"
+  soroban contract spec --wasm "$wasm" --output json \
+    > "artifacts/specs/${base}.json"
+done
+```
+
+If you do not have `soroban-cli` installed:
+
+```sh
+cargo install --locked soroban-cli
+```
+
+---
+
+## 5. CI expectations
+
+| Job | What it checks | Blocks merge? |
+|-----|---------------|---------------|
+| `fmt` | `cargo fmt --all --check` | Yes |
+| `test` | `cargo test --workspace` | Yes |
+| `artifacts` | Contract WASM builds + spec extraction | Yes |
+
+A PR that breaks any of these jobs will not be merged.
+
+If you intentionally change a public contract interface, update the spec JSON
+files as described in §1 and add a note in your PR description explaining the
+change and any migration considerations for existing deployments.


### PR DESCRIPTION
…curity policy

- #192: .github/workflows/release.yml — cross-platform CLI binary builds, contract WASM/spec artifacts, GitHub Release publication, and crates.io publish with a manual approval gate (crates-io environment)
- #194: .github/dependabot.yml — weekly Cargo and GitHub Actions dependency PRs grouped by ecosystem (soroban, serde, clap, misc-patch) with major bumps excluded from automation
- #196: docs/contributing-contracts.md — documents when and how to regenerate contract specs, update snapshots, write cross-contract integration tests, and run the required local validation commands
- #199: SECURITY.md — coordinated disclosure policy with reporting channel, severity scale, in/out-of-scope definitions, and links to existing threat model documentation

closes #192
closes #194
closes #196
closes #199