### PR TITLE
fix(#276, #144): contract-backed SDK quotes and subdomain lifecycle e…

### DIFF
--- a/contracts/subdomain/src/lib.rs
+++ b/contracts/subdomain/src/lib.rs
@@ -1,6 +1,8 @@
 mod test;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+};
 use xlm_ns_common::soroban::{
     build_subdomain_name, validate_base_name_soroban, validate_fqdn_soroban,
 };
@@ -62,6 +64,10 @@ impl SubdomainContract {
             controllers: Vec::new(&env),
         };
         env.storage().persistent().set(&key, &record);
+        env.events().publish(
+            (symbol_short!("subdomain"), symbol_short!("prnt_reg")),
+            (parent, record.owner.clone()),
+        );
         Ok(())
     }
 
@@ -76,10 +82,14 @@ impl SubdomainContract {
             return Err(SubdomainError::Unauthorized);
         }
         if !parent_record.controllers.contains(&controller) {
-            parent_record.controllers.push_back(controller);
+            parent_record.controllers.push_back(controller.clone());
             env.storage()
                 .persistent()
-                .set(&DataKey::Parent(parent), &parent_record);
+                .set(&DataKey::Parent(parent.clone()), &parent_record);
+            env.events().publish(
+                (symbol_short!("subdomain"), symbol_short!("ctrl_add")),
+                (parent, caller, controller),
+            );
         }
         Ok(())
     }
@@ -99,7 +109,11 @@ impl SubdomainContract {
             parent_record.controllers.remove(index);
             env.storage()
                 .persistent()
-                .set(&DataKey::Parent(parent), &parent_record);
+                .set(&DataKey::Parent(parent.clone()), &parent_record);
+            env.events().publish(
+                (symbol_short!("subdomain"), symbol_short!("ctrl_rm")),
+                (parent, caller, controller),
+            );
         }
 
         Ok(())
@@ -135,6 +149,11 @@ impl SubdomainContract {
         add_parent_subdomain(&env, &parent, &fqdn);
         add_owner_subdomain(&env, &owner, &fqdn);
 
+        env.events().publish(
+            (symbol_short!("subdomain"), symbol_short!("created")),
+            (fqdn.clone(), parent, caller, owner),
+        );
+
         Ok(fqdn)
     }
 
@@ -157,6 +176,11 @@ impl SubdomainContract {
         remove_owner_subdomain(&env, &old_owner, &fqdn);
         add_owner_subdomain(&env, &new_owner, &fqdn);
 
+        env.events().publish(
+            (symbol_short!("subdomain"), symbol_short!("transfer")),
+            (fqdn, old_owner, new_owner),
+        );
+
         Ok(())
     }
 
@@ -171,6 +195,11 @@ impl SubdomainContract {
 
         remove_parent_subdomain(&env, &record.parent, &fqdn);
         remove_owner_subdomain(&env, &record.owner, &fqdn);
+
+        env.events().publish(
+            (symbol_short!("subdomain"), symbol_short!("deleted")),
+            (fqdn.clone(), caller),
+        );
 
         env.storage().persistent().remove(&DataKey::Subdomain(fqdn));
 
@@ -198,6 +227,11 @@ impl SubdomainContract {
         if !is_authorized {
             return Err(SubdomainError::Unauthorized);
         }
+
+        env.events().publish(
+            (symbol_short!("subdomain"), symbol_short!("revoked")),
+            (fqdn.clone(), caller),
+        );
 
         env.storage().persistent().remove(&DataKey::Subdomain(fqdn));
         Ok(())

--- a/contracts/subdomain/src/test.rs
+++ b/contracts/subdomain/src/test.rs
@@ -1,8 +1,97 @@
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use soroban_sdk::{testutils::{Address as _, Events as _}, Address, Env, String};
 
     use crate::{SubdomainContract, SubdomainContractClient};
+
+    #[test]
+    fn register_parent_emits_event() {
+        let env = Env::default();
+        let contract_id = env.register(SubdomainContract, ());
+        let client = SubdomainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let parent = String::from_str(&env, "timmy.xlm");
+
+        client.register_parent(&parent, &owner);
+
+        assert_eq!(env.events().all().events().len(), 1);
+    }
+
+    #[test]
+    fn create_subdomain_emits_event() {
+        let env = Env::default();
+        let contract_id = env.register(SubdomainContract, ());
+        let client = SubdomainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let sub_owner = Address::generate(&env);
+        let parent = String::from_str(&env, "timmy.xlm");
+
+        client.register_parent(&parent, &owner);
+        let fqdn = client.create(&String::from_str(&env, "pay"), &parent, &owner, &sub_owner, &100);
+
+        assert_eq!(fqdn, String::from_str(&env, "pay.timmy.xlm"));
+        assert_eq!(env.events().all().events().len(), 1);
+    }
+
+    #[test]
+    fn transfer_emits_event() {
+        let env = Env::default();
+        let contract_id = env.register(SubdomainContract, ());
+        let client = SubdomainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let sub_owner = Address::generate(&env);
+        let new_owner = Address::generate(&env);
+        let parent = String::from_str(&env, "timmy.xlm");
+
+        client.register_parent(&parent, &owner);
+        let fqdn = client.create(&String::from_str(&env, "pay"), &parent, &owner, &sub_owner, &100);
+
+        client.transfer(&fqdn, &sub_owner, &new_owner);
+
+        assert_eq!(env.events().all().events().len(), 1);
+        assert_eq!(client.record(&fqdn).unwrap().owner, new_owner);
+    }
+
+    #[test]
+    fn revoke_emits_event() {
+        let env = Env::default();
+        let contract_id = env.register(SubdomainContract, ());
+        let client = SubdomainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let sub_owner = Address::generate(&env);
+        let parent = String::from_str(&env, "timmy.xlm");
+
+        client.register_parent(&parent, &owner);
+        let fqdn = client.create(&String::from_str(&env, "pay"), &parent, &owner, &sub_owner, &100);
+
+        client.revoke(&fqdn, &sub_owner);
+
+        assert_eq!(env.events().all().events().len(), 1);
+        assert!(!client.exists(&fqdn));
+    }
+
+    #[test]
+    fn add_and_remove_controller_emit_events() {
+        let env = Env::default();
+        let contract_id = env.register(SubdomainContract, ());
+        let client = SubdomainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let controller = Address::generate(&env);
+        let parent = String::from_str(&env, "timmy.xlm");
+
+        client.register_parent(&parent, &owner);
+
+        client.add_controller(&parent, &owner, &controller);
+        assert_eq!(env.events().all().events().len(), 1);
+
+        client.remove_controller(&parent, &owner, &controller);
+        assert_eq!(env.events().all().events().len(), 1);
+    }
 
     #[test]
     fn stores_subdomain_records_in_contract_storage() {

--- a/contracts/subdomain/test_snapshots/test/tests/add_and_remove_controller_emit_events.1.json
+++ b/contracts/subdomain/test_snapshots/test/tests/add_and_remove_controller_emit_events.1.json
@@ -1,0 +1,141 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Parent"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "controllers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "subdomain"
+              },
+              {
+                "symbol": "ctrl_rm"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "timmy.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/subdomain/test_snapshots/test/tests/create_subdomain_emits_event.1.json
+++ b/contracts/subdomain/test_snapshots/test/tests/create_subdomain_emits_event.1.json
@@ -1,0 +1,257 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerSubdomains"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Parent"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "controllers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ParentSubdomains"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Subdomain"
+                  },
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "parent"
+                    },
+                    "val": {
+                      "string": "timmy.xlm"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "subdomain"
+              },
+              {
+                "symbol": "created"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "pay.timmy.xlm"
+                },
+                {
+                  "string": "timmy.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/subdomain/test_snapshots/test/tests/register_parent_emits_event.1.json
+++ b/contracts/subdomain/test_snapshots/test/tests/register_parent_emits_event.1.json
@@ -1,0 +1,136 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Parent"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "controllers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "subdomain"
+              },
+              {
+                "symbol": "prnt_reg"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "timmy.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/subdomain/test_snapshots/test/tests/revoke_emits_event.1.json
+++ b/contracts/subdomain/test_snapshots/test/tests/revoke_emits_event.1.json
@@ -1,0 +1,170 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerSubdomains"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Parent"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "controllers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ParentSubdomains"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/subdomain/test_snapshots/test/tests/transfer_emits_event.1.json
+++ b/contracts/subdomain/test_snapshots/test/tests/transfer_emits_event.1.json
@@ -1,0 +1,249 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerSubdomains"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerSubdomains"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Parent"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "controllers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ParentSubdomains"
+                  },
+                  {
+                    "string": "timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Subdomain"
+                  },
+                  {
+                    "string": "pay.timmy.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "parent"
+                    },
+                    "val": {
+                      "string": "timmy.xlm"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/packages/xlm-ns-sdk/src/client.rs
+++ b/packages/xlm-ns-sdk/src/client.rs
@@ -11,14 +11,24 @@ use crate::types::{
 };
 use std::collections::HashMap;
 use stellar_rpc_client::Client;
+use xlm_ns_common::{GRACE_PERIOD_SECONDS, YEAR_SECONDS};
 
 const MOCK_REFERENCE_TIMESTAMP: u64 = 1_682_200_000;
 const SECONDS_PER_YEAR: u64 = 31_536_000;
 const BASE_FEE_PER_YEAR: u64 = 10;
-const PREMIUM_FEE: u64 = 0;
 const NETWORK_FEE: u64 = 1;
 const MAX_TRANSACTION_POLL_ATTEMPTS: u32 = 60;
 const TRANSACTION_POLL_INTERVAL_MS: u64 = 1000;
+
+/// Mirrors the registrar contract's `price_for_label_length` so SDK quote
+/// values stay in parity with the deployed contract without an RPC round-trip.
+fn price_for_label_length(length: usize) -> u64 {
+    match length {
+        0..=3 => 1_000_000_000,
+        4..=6 => 250_000_000,
+        _ => 100_000_000,
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct XlmNsClient {
@@ -321,15 +331,30 @@ impl XlmNsClient {
                 "duration_years must be greater than zero".into(),
             ));
         }
+        let registrar_id = self
+            .registrar_contract_id
+            .as_ref()
+            .ok_or_else(|| {
+                SdkError::InvalidRequest("registrar contract ID not configured".into())
+            })?
+            .clone();
 
         let years = u64::from(duration_years);
+        let annual_fee = price_for_label_length(label.trim().len());
+        let base_fee = annual_fee.saturating_mul(years);
         let fee_breakdown = FeeBreakdown {
-            base_fee: BASE_FEE_PER_YEAR.saturating_mul(years),
-            premium_fee: PREMIUM_FEE,
-            network_fee: NETWORK_FEE,
+            base_fee,
+            premium_fee: 0,
+            network_fee: 0,
         };
         let total_fee = fee_breakdown.total();
-        let expires_at = MOCK_REFERENCE_TIMESTAMP + years * SECONDS_PER_YEAR;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let expires_at = now.saturating_add(years.saturating_mul(YEAR_SECONDS));
+        let grace_period_ends_at = expires_at.saturating_add(GRACE_PERIOD_SECONDS);
 
         Ok(RegistrationQuote {
             label: label.to_string(),
@@ -338,8 +363,9 @@ impl XlmNsClient {
             total_fee,
             fee_currency: DEFAULT_FEE_CURRENCY.to_string(),
             expires_at,
-            quoted_at: MOCK_REFERENCE_TIMESTAMP,
-            contract_id: self.registrar_contract_id.clone(),
+            grace_period_ends_at,
+            quoted_at: now,
+            contract_id: Some(registrar_id),
         })
     }
 

--- a/packages/xlm-ns-sdk/src/tests.rs
+++ b/packages/xlm-ns-sdk/src/tests.rs
@@ -38,18 +38,23 @@ mod tests {
 
     #[tokio::test]
     async fn registration_quote_exposes_breakdown() {
+        // "alpha" = 5 chars → 250_000_000 stroops/year (contract tier: 4–6 chars)
         let quote = client().quote_registration("alpha", 3).await.unwrap();
         assert_eq!(quote.label, "alpha");
         assert_eq!(quote.duration_years, 3);
-        assert_eq!(quote.fee_breakdown.base_fee, 30);
-        assert_eq!(quote.fee_breakdown.network_fee, 1);
-        assert_eq!(quote.total_fee, 31);
+        assert_eq!(quote.fee_breakdown.base_fee, 750_000_000); // 250_000_000 × 3
+        assert_eq!(quote.fee_breakdown.premium_fee, 0);
+        assert_eq!(quote.fee_breakdown.network_fee, 0);
+        assert_eq!(quote.total_fee, 750_000_000);
         assert_eq!(quote.fee_currency, "XLM");
         assert!(quote.contract_id.is_some());
+        assert!(quote.expires_at > quote.quoted_at);
+        assert!(quote.grace_period_ends_at > quote.expires_at);
     }
 
     #[tokio::test]
     async fn registration_receipt_carries_submission_metadata() {
+        // "beta" = 4 chars → 250_000_000 stroops/year (contract tier: 4–6 chars)
         let receipt = client()
             .register(RegistrationRequest {
                 label: "beta".into(),
@@ -62,7 +67,7 @@ mod tests {
 
         assert_eq!(receipt.name, "beta.xlm");
         assert_eq!(receipt.duration_years, 1);
-        assert_eq!(receipt.fee_paid, 11);
+        assert_eq!(receipt.fee_paid, 250_000_000); // 250_000_000 × 1
         assert_eq!(receipt.submission.signer.as_deref(), Some("treasury"));
         assert!(receipt.submission.network_passphrase.is_some());
     }
@@ -190,6 +195,7 @@ mod tests {
 
     #[tokio::test]
     async fn register_builds_real_submission() {
+        // "gamma" = 5 chars → 250_000_000 stroops/year (contract tier: 4–6 chars)
         let receipt = client()
             .register(RegistrationRequest {
                 label: "gamma".into(),
@@ -200,11 +206,10 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify receipt structure carries tx metadata
         assert_eq!(receipt.name, "gamma.xlm");
         assert_eq!(receipt.owner, "GDRA...OWNER");
         assert_eq!(receipt.duration_years, 2);
-        assert_eq!(receipt.fee_paid, 21); // 2 years * 10 base + 1 network
+        assert_eq!(receipt.fee_paid, 500_000_000); // 250_000_000 × 2
         assert_eq!(receipt.submission.status, SubmissionStatus::Submitted);
         assert_eq!(receipt.submission.signer.as_deref(), Some("registrar"));
         assert!(!receipt.submission.tx_hash.is_empty());
@@ -333,6 +338,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn quote_requires_registrar_contract() {
+        let no_registrar = XlmNsClient::builder("http://localhost")
+            .registry("CDAD...REGISTRY")
+            .build();
+
+        let result = no_registrar.quote_registration("alpha", 1).await;
+        match result {
+            Err(SdkError::InvalidRequest(msg)) => {
+                assert!(msg.contains("registrar"));
+            }
+            _ => panic!("Expected InvalidRequest when registrar contract ID is missing"),
+        }
+    }
+
+    #[tokio::test]
     async fn register_requires_registrar_contract() {
         let no_registrar_client = XlmNsClient::builder("http://localhost")
             .registry("CDAD...REGISTRY")
@@ -381,11 +401,14 @@ mod tests {
 
     #[tokio::test]
     async fn submission_includes_fee_breakdown() {
+        // "epsilon" = 7 chars → 100_000_000 stroops/year (contract tier: 7+ chars)
         let quote = client().quote_registration("epsilon", 4).await.unwrap();
 
-        assert_eq!(quote.fee_breakdown.base_fee, 40);
-        assert_eq!(quote.fee_breakdown.network_fee, 1);
-        assert_eq!(quote.total_fee, 41);
+        assert_eq!(quote.fee_breakdown.base_fee, 400_000_000); // 100_000_000 × 4
+        assert_eq!(quote.fee_breakdown.premium_fee, 0);
+        assert_eq!(quote.fee_breakdown.network_fee, 0);
+        assert_eq!(quote.total_fee, 400_000_000);
+        assert!(quote.grace_period_ends_at > quote.expires_at);
 
         let receipt = client()
             .register(RegistrationRequest {
@@ -397,7 +420,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(receipt.fee_paid, 41);
+        assert_eq!(receipt.fee_paid, 400_000_000);
         assert_eq!(
             receipt.submission.network_passphrase,
             Some("Test SDF Network ; September 2015".into())

--- a/packages/xlm-ns-sdk/src/types.rs
+++ b/packages/xlm-ns-sdk/src/types.rs
@@ -146,6 +146,7 @@ pub struct RegistrationQuote {
     pub total_fee: u64,
     pub fee_currency: String,
     pub expires_at: u64,
+    pub grace_period_ends_at: u64,
     pub quoted_at: u64,
     pub contract_id: Option<String>,
 }


### PR DESCRIPTION
…vents

closes #276 – Replace SDK mock registrar quote logic with contract-backed quotes:
- Add `price_for_label_length` to `xlm-ns-sdk` that mirrors the registrar contract's pricing tiers (≤3 chars: 1B, 4-6: 250M, 7+: 100M stroops/year).
- `quote_registration` now requires a configured registrar contract ID, uses real system time for `quoted_at`/`expires_at`, derives `grace_period_ends_at` from `xlm_ns_common::GRACE_PERIOD_SECONDS`, and sets `network_fee = 0` and `premium_fee = 0` matching the deployed contract.
- Add `grace_period_ends_at` field to `RegistrationQuote` so callers can see the full expiry lifecycle in parity with the contract's `RegistrationQuote`.
- Add `quote_requires_registrar_contract` test (validation-failure path).
- Update affected test assertions to use contract pricing values.

closes #144 – Emit subdomain lifecycle events:
- Emit `(subdomain, prnt_reg)` on `register_parent`.
- Emit `(subdomain, ctrl_add)` on `add_controller` (only when actually added).
- Emit `(subdomain, ctrl_rm)` on `remove_controller` (only when actually removed).
- Emit `(subdomain, created)` on `create`.
- Emit `(subdomain, transfer)` on `transfer`.
- Emit `(subdomain, deleted)` on `delete`.
- Emit `(subdomain, revoked)` on `revoke`.
- Add 5 new tests: `register_parent_emits_event`, `create_subdomain_emits_event`, `transfer_emits_event`, `revoke_emits_event`, `add_and_remove_controller_emit_events`.
- Add Soroban test snapshots for the new event tests.

## Summary

<!-- Describe what this PR changes and why. -->

Closes #<!-- issue number -->

## Change type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Contract change

## Areas affected

- [ ] CLI (`cli/`)
- [ ] Contracts (`contracts/`)
- [ ] SDK (`packages/xlm-ns-sdk/`)
- [ ] Common types (`packages/xlm-ns-common/`)
- [ ] CI / GitHub Actions
- [ ] Docs

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] Contract changes: `cargo build --release --target wasm32-unknown-unknown` succeeds
- [ ] New functionality covered by tests or snapshots
- [ ] Manually verified on testnet (for contract / CLI changes)

## Rollout notes

<!-- Anything reviewers or deployers should know: breaking changes, migration steps, env var changes. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] No secrets or credentials committed
- [ ] PR title is descriptive
- [ ] Linked the issue above
