### PR TITLE
feat: registrar renewal quote + pricing version, registry name-state query, renewal boundary tests

### DIFF
--- a/contracts/registrar/src/lib.rs
+++ b/contracts/registrar/src/lib.rs
@@ -32,6 +32,19 @@ pub struct RegistrationQuote {
     pub pricing: PricingBreakdown,
 }
 
+/// Issue #220: Renewal-specific quote. Unlike [`RegistrationQuote`] this is for
+/// an already-registered name and reports both the current and the post-renewal
+/// expiry so callers can see exactly how a renewal extends the lifecycle.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RenewalQuote {
+    pub fee_stroops: u64,
+    pub current_expiry_unix: u64,
+    pub extended_expiry_unix: u64,
+    pub grace_period_ends_at: u64,
+    pub pricing: PricingBreakdown,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct RegistrarMetrics {
@@ -155,6 +168,54 @@ impl RegistrarContract {
         validate_label_soroban(&label).map_err(|_| RegistrarError::Validation)?;
         validate_registration_years_soroban(years).map_err(|_| RegistrarError::Validation)?;
         Ok(build_quote(&label, years, now_unix))
+    }
+
+    /// Issue #220: Read-only renewal quote for an existing registration.
+    ///
+    /// Mirrors the fee and expiry math in [`renew`] (renewing from the later of
+    /// the current expiry or `now`) without mutating state or requiring auth.
+    /// Returns [`RegistrarError::NotFound`] if the name has never been registered.
+    pub fn quote_renewal(
+        env: Env,
+        name: String,
+        years: u64,
+        now_unix: u64,
+    ) -> Result<RenewalQuote, RegistrarError> {
+        let label = extract_label_soroban(&env, &name).map_err(|_| RegistrarError::Validation)?;
+        validate_registration_years_soroban(years).map_err(|_| RegistrarError::Validation)?;
+
+        let record = env
+            .storage()
+            .persistent()
+            .get::<_, RegistrationRecord>(&DataKey::Registration(name))
+            .ok_or(RegistrarError::NotFound)?;
+
+        // Renewal extends from the later of the current expiry or now, matching `renew`.
+        let base_time = if record.expires_at > now_unix {
+            record.expires_at
+        } else {
+            now_unix
+        };
+        let extended_expiry_unix = expiry_from_now(base_time, years);
+        let annual_fee = price_for_label_length(label.len() as usize);
+
+        Ok(RenewalQuote {
+            fee_stroops: annual_fee.saturating_mul(years),
+            current_expiry_unix: record.expires_at,
+            extended_expiry_unix,
+            grace_period_ends_at: extended_expiry_unix.saturating_add(GRACE_PERIOD_SECONDS),
+            pricing: PricingBreakdown {
+                annual_fee_stroops: annual_fee,
+                duration_years: years,
+                premium_stroops: 0,
+            },
+        })
+    }
+
+    /// Issue #217: Read-only version of the pricing policy table so clients can
+    /// detect quote-policy changes without diffing individual quotes.
+    pub fn pricing_policy_version(_env: Env) -> u32 {
+        pricing::PRICING_POLICY_VERSION
     }
 
     pub fn register(

--- a/contracts/registrar/src/pricing.rs
+++ b/contracts/registrar/src/pricing.rs
@@ -1,3 +1,8 @@
+/// Version of the registrar pricing policy. Bump this whenever the tier
+/// boundaries or amounts in [`price_for_label_length`] change so off-chain
+/// clients can detect quote-policy changes without diffing every quote.
+pub const PRICING_POLICY_VERSION: u32 = 1;
+
 pub fn price_for_label_length(length: usize) -> u64 {
     match length {
         0..=3 => 1_000_000_000,

--- a/contracts/registrar/src/test.rs
+++ b/contracts/registrar/src/test.rs
@@ -179,6 +179,62 @@ mod tests {
     }
 
     #[test]
+    fn quote_renewal_reports_current_and_extended_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+        let registry_id = env.register(RegistryContract, ());
+        client.initialize(&registry_id);
+
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "alice");
+        let name = String::from_str(&env, "alice.xlm");
+
+        let reg_quote = client.quote_registration(&label, &1, &100);
+        client.register(&label, &owner, &1, &reg_quote.fee_stroops, &100);
+
+        let renewal = client.quote_renewal(&name, &2, &200);
+        assert_eq!(renewal.current_expiry_unix, reg_quote.expiry_unix);
+        assert!(renewal.extended_expiry_unix > renewal.current_expiry_unix);
+        assert_eq!(
+            renewal.grace_period_ends_at,
+            renewal.extended_expiry_unix + GRACE_PERIOD_SECONDS
+        );
+        // 5-char label → 250_000_000 stroops/year × 2 years.
+        assert_eq!(renewal.fee_stroops, 500_000_000);
+        assert_eq!(renewal.pricing.annual_fee_stroops, 250_000_000);
+        assert_eq!(renewal.pricing.duration_years, 2);
+    }
+
+    #[test]
+    fn quote_renewal_fails_for_unregistered_name() {
+        let env = Env::default();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+        let registry_id = env.register(RegistryContract, ());
+        client.initialize(&registry_id);
+
+        let name = String::from_str(&env, "ghost.xlm");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.quote_renewal(&name, &1, &100);
+        }));
+        assert!(
+            result.is_err(),
+            "quote_renewal should fail for an unregistered name"
+        );
+    }
+
+    #[test]
+    fn pricing_policy_version_is_exposed() {
+        let env = Env::default();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+
+        assert_eq!(client.pricing_policy_version(), 1);
+    }
+
+    #[test]
     fn quote_includes_pricing_breakdown() {
         let env = Env::default();
         let contract_id = env.register(RegistrarContract, ());

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -33,6 +33,21 @@ impl RegistryEntry {
     }
 }
 
+/// Issue #213: Lifecycle state of a name, so callers can branch on the state
+/// directly instead of inferring it from `resolve`/`register` errors.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum NameState {
+    /// No entry exists for this name.
+    Missing,
+    /// Registered and not yet expired.
+    Active,
+    /// Expired but still within the grace period (only the owner may renew).
+    GracePeriod,
+    /// Past the grace period; anyone may claim/register it.
+    Claimable,
+}
+
 #[derive(Clone)]
 #[contracttype]
 enum DataKey {
@@ -126,6 +141,29 @@ impl RegistryContract {
             return Err(RegistryError::NotActive);
         }
         Ok(entry)
+    }
+
+    /// Issue #213: Read-only lifecycle state of a name, distinguishing active,
+    /// grace-period, claimable, and missing names without forcing callers to
+    /// infer the state from `resolve`/`register` errors. Unknown or invalid
+    /// names report as [`NameState::Missing`].
+    pub fn name_state(env: Env, name: String, now_unix: u64) -> NameState {
+        match env
+            .storage()
+            .persistent()
+            .get::<_, RegistryEntry>(&DataKey::Entry(name))
+        {
+            None => NameState::Missing,
+            Some(entry) => {
+                if entry.is_active_at(now_unix) {
+                    NameState::Active
+                } else if entry.is_claimable_at(now_unix) {
+                    NameState::Claimable
+                } else {
+                    NameState::GracePeriod
+                }
+            }
+        }
     }
 
     pub fn check_owner(

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
-    use crate::{RegistryContract, RegistryContractClient, RegistryError};
+    use crate::{NameState, RegistryContract, RegistryContractClient, RegistryError};
 
     struct TimeHelper {
         pub now: u64,
@@ -52,6 +52,51 @@ mod tests {
         let resolved = client.resolve(&name, &transfer_time);
         assert_eq!(resolved.owner, next_owner);
         assert_eq!(client.names_for_owner(&next_owner).len(), 1);
+    }
+
+    #[test]
+    fn name_state_distinguishes_lifecycle_phases() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let name = String::from_str(&env, "phase.xlm");
+        let time = TimeHelper::new();
+        let expires_at = time.future(1_000);
+        let grace_period_ends_at = time.future(2_000);
+
+        // Missing before any registration exists.
+        assert_eq!(client.name_state(&name, &time.now), NameState::Missing);
+
+        client.register(
+            &name,
+            &owner,
+            &None::<String>,
+            &None::<String>,
+            &time.now,
+            &expires_at,
+            &grace_period_ends_at,
+        );
+
+        // Active up to and including the expiry instant.
+        assert_eq!(client.name_state(&name, &time.future(500)), NameState::Active);
+        assert_eq!(client.name_state(&name, &expires_at), NameState::Active);
+        // Grace period between expiry and the grace-period end (inclusive).
+        assert_eq!(
+            client.name_state(&name, &time.future(1_500)),
+            NameState::GracePeriod
+        );
+        assert_eq!(
+            client.name_state(&name, &grace_period_ends_at),
+            NameState::GracePeriod
+        );
+        // Claimable strictly after the grace period ends.
+        assert_eq!(
+            client.name_state(&name, &(grace_period_ends_at + 1)),
+            NameState::Claimable
+        );
     }
 
     #[test]

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -109,3 +109,41 @@ Read-only aggregate view for operator reconciliation. Returns the same
 
 No write to storage is performed; this function is safe to call at any
 time without side-effects.
+
+### `quote_renewal(name, years, now_unix) -> RenewalQuote` (#220)
+
+Read-only renewal quote for an already-registered name. Mirrors the fee and
+expiry math in `renew` (renewing from the later of the current expiry or
+`now_unix`) without mutating state or requiring auth.
+
+`RenewalQuote`:
+
+- `fee_stroops` (u64): total renewal fee (annual fee × `years`).
+- `current_expiry_unix` (u64): the registration's current expiry.
+- `extended_expiry_unix` (u64): expiry after the renewal would apply.
+- `grace_period_ends_at` (u64): grace-period end derived from the extended expiry.
+- `pricing` (`PricingBreakdown`): annual fee, duration, premium.
+
+Returns `NotFound` if the name has never been registered.
+
+### `pricing_policy_version() -> u32` (#217)
+
+Read-only version of the registrar pricing table. Clients can poll this to
+detect quote-policy changes without diffing individual quotes. The value is
+bumped whenever the tiers/amounts in `price_for_label_length` change.
+
+## Registry
+
+### `name_state(name, now_unix) -> NameState` (#213)
+
+Read-only lifecycle state of a name so callers can branch on the state directly
+rather than inferring it from `resolve`/`register` errors.
+
+| Variant | Meaning |
+|---------|---------|
+| `Missing` | No entry exists (also returned for unknown/invalid names). |
+| `Active` | Registered and not yet expired (`now_unix <= expires_at`). |
+| `GracePeriod` | Expired but within grace window (`expires_at < now_unix <= grace_period_ends_at`). |
+| `Claimable` | Past grace period (`now_unix > grace_period_ends_at`); anyone may claim. |
+
+No write to storage is performed.

--- a/tests/integration/registrar_registry_test.rs
+++ b/tests/integration/registrar_registry_test.rs
@@ -9,7 +9,7 @@
 mod registrar_registry_integration {
     use soroban_sdk::{testutils::Address as _, Address, Env, String};
     use xlm_ns_registrar::{RegistrarContract, RegistrarContractClient};
-    use xlm_ns_registry::{RegistryContract, RegistryContractClient};
+    use xlm_ns_registry::{NameState, RegistryContract, RegistryContractClient};
 
     struct TimeHelper {
         pub now: u64,
@@ -181,5 +181,82 @@ mod registrar_registry_integration {
         // The original owner should still remain the owner in the registrar record
         let reg_record = registrar.registration(&name).unwrap();
         assert_eq!(reg_record.owner, owner1);
+    }
+
+    /// Issue #214: renewal exactly at the expiry instant succeeds and the
+    /// registry reflects the extended lifecycle.
+    #[test]
+    fn renewal_at_exact_expiry_succeeds_cross_contract() {
+        let (env, registrar, registry) = setup_env();
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "edgeone");
+        let name = String::from_str(&env, "edgeone.xlm");
+        let start = 10_000_000u64;
+
+        let quote = registrar.quote_registration(&label, &1, &start);
+        registrar.register(&label, &owner, &1, &quote.fee_stroops, &start);
+
+        let at_expiry = quote.expiry_unix;
+        registrar.renew(&name, &owner, &1, &quote.fee_stroops, &at_expiry);
+
+        let record = registrar.registration(&name).unwrap();
+        let entry = registry.resolve(&name, &at_expiry);
+        assert!(record.expires_at > quote.expiry_unix);
+        assert_eq!(record.expires_at, entry.expires_at);
+        assert_eq!(record.grace_period_ends_at, entry.grace_period_ends_at);
+    }
+
+    /// Issue #214: renewal inside the grace period succeeds; the registry tracks
+    /// the new expiry even though the name was expired at renewal time.
+    #[test]
+    fn renewal_inside_grace_period_succeeds_cross_contract() {
+        let (env, registrar, registry) = setup_env();
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "edgetwo");
+        let name = String::from_str(&env, "edgetwo.xlm");
+        let start = 20_000_000u64;
+
+        let quote = registrar.quote_registration(&label, &1, &start);
+        registrar.register(&label, &owner, &1, &quote.fee_stroops, &start);
+
+        // Midpoint of the grace window: expiry < now < grace_end.
+        let in_grace =
+            quote.expiry_unix + (quote.grace_period_ends_at - quote.expiry_unix) / 2;
+        assert_eq!(registry.name_state(&name, &in_grace), NameState::GracePeriod);
+
+        registrar.renew(&name, &owner, &1, &quote.fee_stroops, &in_grace);
+
+        let record = registrar.registration(&name).unwrap();
+        let entry = registry.resolve(&name, &in_grace);
+        assert!(record.expires_at > in_grace);
+        assert_eq!(record.expires_at, entry.expires_at);
+        assert_eq!(registry.name_state(&name, &in_grace), NameState::Active);
+    }
+
+    /// Issue #214: renewal immediately after the grace period ends must revert
+    /// and leave both contracts' state unchanged (registry name is claimable).
+    #[test]
+    fn renewal_after_grace_period_fails_cross_contract() {
+        let (env, registrar, registry) = setup_env();
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "edgethree");
+        let name = String::from_str(&env, "edgethree.xlm");
+        let start = 30_000_000u64;
+
+        let quote = registrar.quote_registration(&label, &1, &start);
+        registrar.register(&label, &owner, &1, &quote.fee_stroops, &start);
+
+        let after_grace = quote.grace_period_ends_at + 1;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            registrar.renew(&name, &owner, &1, &quote.fee_stroops, &after_grace);
+        }));
+        assert!(result.is_err(), "renewal after grace period should revert");
+
+        // Registrar record keeps its original (un-extended) expiry.
+        let record = registrar.registration(&name).unwrap();
+        assert_eq!(record.expires_at, quote.expiry_unix);
+
+        // Registry reports the name as claimable, untouched by the failed renewal.
+        assert_eq!(registry.name_state(&name, &after_grace), NameState::Claimable);
     }
 }


### PR DESCRIPTION
## Summary

### #220 — Registrar renewal quote entrypoints
Added read-only `quote_renewal(name, years, now_unix) -> RenewalQuote`. Unlike `quote_registration` it operates on an already-registered name and reports both the **current** and **post-renewal** expiry plus the grace-period end and fee breakdown. The fee/expiry math mirrors `renew` exactly (renews from the later of the current expiry or `now`). Returns `NotFound` for unregistered names. No storage write, no auth.

### #217 — Registrar pricing policy version query
Added `pricing_policy_version() -> u32` backed by a `PRICING_POLICY_VERSION` constant in `pricing.rs`, so clients can detect quote-policy changes without diffing individual quotes (bump the constant when the tiers change).

### #213 — Registry claimable-state query
Added `name_state(name, now_unix) -> NameState` returning `Active` / `GracePeriod` / `Claimable` / `Missing`, so callers can branch on lifecycle state directly instead of inferring it from `resolve`/`register` errors.

### #214 — Cross-contract renewal boundary tests
Added registrar→registry integration tests covering renewal **exactly at expiry**, **inside the grace period**, and **immediately after grace ends** (the last must revert and leave the registry name claimable). They also assert the registry's new `name_state` transitions across the boundary.

Documented all three new entrypoints in `docs/schemas.md`.

## Test plan
- [x] `cargo test -p xlm-ns-registry` — 14/14 pass, incl. the new `name_state` lifecycle test.
- [x] `cargo test -p xlm-ns-registrar` — the new `quote_renewal_*` and `pricing_policy_version_is_exposed` tests pass.
- [ ] `cargo test -p xlm-ns-integration-tests --test registrar_registry_test` — see out-of-scope note.

## Out of scope (pre-existing on `main`)
- **`xlm-ns-registrar` unit tests:** 11 existing register/renew tests fail with `Error(Auth, InvalidAction)` because they never call `env.mock_all_auths()` and the resolved `soroban-env-host` is 26.x (stricter than the 21.x they targeted). This is unchanged by this PR (same 11 fail on `main`); the 3 tests added here mock auth and pass.
- **`xlm-ns-resolver` does not compile** on `main` (4 soroban-26 migration errors), and the integration-tests crate dev-depends on it — so the new #214 boundary tests can't be executed until the resolver crate is fixed. The tests are written against the working registrar+registry contracts and use `mock_all_auths`.

Closes #312
Closes #309
Closes #306
Closes #305