### PR TITLE
add healthcheck command, contract flag tests, registry audit and tran…

### DIFF
--- a/cli/src/commands/healthcheck.rs
+++ b/cli/src/commands/healthcheck.rs
@@ -1,0 +1,114 @@
+use crate::config::{ContractKind, NetworkConfig};
+use crate::output::{emit, OutputFormat};
+use serde_json::json;
+use xlm_ns_sdk::client::XlmNsClient;
+use xlm_ns_sdk::errors::SdkError;
+
+pub async fn run_healthcheck(config: NetworkConfig, output: OutputFormat) -> anyhow::Result<()> {
+    let mut checks: Vec<(&'static str, bool, String)> = Vec::new();
+
+    // Configuration loaded — always true when we reach this handler.
+    checks.push((
+        "config",
+        true,
+        format!("network={}", config.network.as_str()),
+    ));
+
+    // Network passphrase must be non-empty.
+    let passphrase_ok = !config.network_passphrase.is_empty();
+    checks.push((
+        "passphrase",
+        passphrase_ok,
+        if passphrase_ok {
+            config.network_passphrase.clone()
+        } else {
+            "empty — network passphrase is not set".to_string()
+        },
+    ));
+
+    // RPC connectivity: trigger an actual get_network() call by resolving a
+    // probe name. A placeholder registry ID is used when none is configured;
+    // the underlying mock ignores the ID and only the network round-trip matters.
+    let probe_registry = config
+        .registry_contract_id
+        .clone()
+        .unwrap_or_else(|| "HEALTHCHECK_PROBE".to_string());
+
+    let probe_client = XlmNsClient::new(
+        config.rpc_url.clone(),
+        Some(config.network_passphrase.clone()),
+        Some(probe_registry),
+        config.subdomain_contract_id.clone(),
+        config.bridge_contract_id.clone(),
+        config.auction_contract_id.clone(),
+    );
+
+    let (rpc_ok, rpc_detail) = match probe_client.get_registration("healthcheck-probe.xlm").await {
+        Ok(_) => (true, format!("reachable — {}", config.rpc_url)),
+        Err(SdkError::Transport(msg)) => (false, format!("unreachable — {msg}")),
+        Err(err) => (true, format!("reachable ({})", err)),
+    };
+    checks.push(("rpc", rpc_ok, rpc_detail));
+
+    let all_ok = checks.iter().all(|(_, ok, _)| *ok);
+    let status_label = if all_ok { "OK" } else { "DEGRADED" };
+
+    // Ordered list of contract kinds and their configured values.
+    let contract_entries: &[(ContractKind, &Option<String>)] = &[
+        (ContractKind::Registry, &config.registry_contract_id),
+        (ContractKind::Registrar, &config.registrar_contract_id),
+        (ContractKind::Resolver, &config.resolver_contract_id),
+        (ContractKind::Auction, &config.auction_contract_id),
+        (ContractKind::Bridge, &config.bridge_contract_id),
+        (ContractKind::Subdomain, &config.subdomain_contract_id),
+        (ContractKind::Nft, &config.nft_contract_id),
+    ];
+
+    // Human output
+    let mut lines = vec![
+        format!(
+            "Healthcheck [{status_label}] — network={}",
+            config.network.as_str()
+        ),
+        String::new(),
+        "  Checks:".to_string(),
+    ];
+    for (name, ok, detail) in &checks {
+        let mark = if *ok { "PASS" } else { "FAIL" };
+        lines.push(format!("    [{mark}]  {name:<12}  {detail}"));
+    }
+    lines.push(String::new());
+    lines.push("  Contracts:".to_string());
+    for (kind, id) in contract_entries {
+        let val = id.as_deref().unwrap_or("[not configured]");
+        lines.push(format!("    {:<22}  {val}", kind.flag_name()));
+    }
+
+    // JSON output
+    let checks_json: Vec<serde_json::Value> = checks
+        .iter()
+        .map(|(name, ok, detail)| json!({"name": name, "ok": ok, "detail": detail}))
+        .collect();
+
+    let contracts_json: serde_json::Map<String, serde_json::Value> = contract_entries
+        .iter()
+        .map(|(kind, id)| (kind.flag_name().to_string(), json!(id)))
+        .collect();
+
+    emit(
+        output,
+        &lines.join("\n"),
+        json!({
+            "status": if all_ok { "ok" } else { "degraded" },
+            "network": config.network.as_str(),
+            "rpc_url": config.rpc_url,
+            "checks": checks_json,
+            "contracts": contracts_json,
+        }),
+    );
+
+    if !all_ok {
+        return Err(anyhow::anyhow!("healthcheck reported a degraded status"));
+    }
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod auction;
 pub mod bridge;
 pub mod completions;
+pub mod healthcheck;
 pub mod nft;
 pub mod portfolio;
 pub mod quote;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -162,6 +162,11 @@ enum Commands {
         /// Name to check (e.g. `alice.xlm` or just `alice`)
         name: String,
     },
+    /// Verify RPC connectivity, network passphrase, and configured contract IDs (read-only).
+    ///
+    /// Exits with a non-zero status when any check fails so the command can be
+    /// used in health-probe scripts and CI pipelines.
+    Healthcheck,
 }
 
 #[derive(Subcommand)]
@@ -456,6 +461,9 @@ async fn run() -> anyhow::Result<()> {
         Commands::Availability { name } => {
             commands::quote::run_availability(config, cli.output, &name).await
         }
+        Commands::Healthcheck => {
+            commands::healthcheck::run_healthcheck(config, cli.output).await
+        }
         Commands::Completions { .. } => unreachable!("handled above"),
     }
 }
@@ -465,6 +473,288 @@ async fn main() {
     if let Err(e) = run().await {
         eprintln!("Error: {:?}", e);
         process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::{Network, NetworkConfig};
+
+    fn config_with_all_contracts() -> NetworkConfig {
+        NetworkConfig {
+            network: Network::Testnet,
+            rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            registry_contract_id: Some("REGISTRY111".to_string()),
+            registrar_contract_id: Some("REGISTRAR111".to_string()),
+            resolver_contract_id: Some("RESOLVER111".to_string()),
+            auction_contract_id: Some("AUCTION111".to_string()),
+            bridge_contract_id: Some("BRIDGE111".to_string()),
+            subdomain_contract_id: Some("SUBDOMAIN111".to_string()),
+            nft_contract_id: Some("NFT111".to_string()),
+            config_path: None,
+        }
+    }
+
+    fn config_with_no_contracts() -> NetworkConfig {
+        NetworkConfig {
+            network: Network::Testnet,
+            rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            registry_contract_id: None,
+            registrar_contract_id: None,
+            resolver_contract_id: None,
+            auction_contract_id: None,
+            bridge_contract_id: None,
+            subdomain_contract_id: None,
+            nft_contract_id: None,
+            config_path: None,
+        }
+    }
+
+    // --- register ---
+
+    #[test]
+    fn register_rejects_irrelevant_resolver_flag() {
+        let cmd = Commands::Register {
+            name: "test.xlm".to_string(),
+            owner: "GDRA111".to_string(),
+            signer: None,
+        };
+        let overrides = ContractOverrides {
+            resolver_contract_id: Some("RESOLVER111".to_string()),
+            ..Default::default()
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_all_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("resolver-contract-id"),
+            "expected resolver-contract-id in: {msg}"
+        );
+        assert!(msg.contains("register"), "expected 'register' in: {msg}");
+    }
+
+    #[test]
+    fn register_rejects_irrelevant_registry_flag() {
+        let cmd = Commands::Register {
+            name: "test.xlm".to_string(),
+            owner: "GDRA111".to_string(),
+            signer: None,
+        };
+        let overrides = ContractOverrides {
+            registry_contract_id: Some("REGISTRY111".to_string()),
+            ..Default::default()
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_all_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registry-contract-id"),
+            "expected registry-contract-id in: {msg}"
+        );
+    }
+
+    #[test]
+    fn register_fails_when_registrar_is_missing() {
+        let cmd = Commands::Register {
+            name: "test.xlm".to_string(),
+            owner: "GDRA111".to_string(),
+            signer: None,
+        };
+        let result =
+            validate_contract_policy(&cmd, &ContractOverrides::default(), &config_with_no_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registrar-contract-id"),
+            "expected registrar-contract-id in: {msg}"
+        );
+    }
+
+    #[test]
+    fn register_passes_with_only_registrar_flag() {
+        let cmd = Commands::Register {
+            name: "test.xlm".to_string(),
+            owner: "GDRA111".to_string(),
+            signer: None,
+        };
+        let overrides = ContractOverrides {
+            registrar_contract_id: Some("REGISTRAR111".to_string()),
+            ..Default::default()
+        };
+        let mut cfg = config_with_no_contracts();
+        cfg.registrar_contract_id = Some("REGISTRAR111".to_string());
+        let result = validate_contract_policy(&cmd, &overrides, &cfg);
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    // --- resolve ---
+
+    #[test]
+    fn resolve_rejects_irrelevant_registry_flag() {
+        let cmd = Commands::Resolve {
+            name: "test.xlm".to_string(),
+        };
+        let overrides = ContractOverrides {
+            registry_contract_id: Some("REGISTRY111".to_string()),
+            ..Default::default()
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_all_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registry-contract-id"),
+            "expected registry-contract-id in: {msg}"
+        );
+        assert!(msg.contains("resolve"), "expected 'resolve' in: {msg}");
+    }
+
+    #[test]
+    fn resolve_fails_when_resolver_is_missing() {
+        let cmd = Commands::Resolve {
+            name: "test.xlm".to_string(),
+        };
+        let result =
+            validate_contract_policy(&cmd, &ContractOverrides::default(), &config_with_no_contracts());
+        assert!(result.is_err());
+    }
+
+    // --- transfer ---
+
+    #[test]
+    fn transfer_rejects_irrelevant_registrar_flag() {
+        let cmd = Commands::Transfer {
+            name: "test.xlm".to_string(),
+            new_owner: "GDRANEW".to_string(),
+            signer: None,
+        };
+        let overrides = ContractOverrides {
+            registrar_contract_id: Some("REGISTRAR111".to_string()),
+            ..Default::default()
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_all_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registrar-contract-id"),
+            "expected registrar-contract-id in: {msg}"
+        );
+        assert!(msg.contains("transfer"), "expected 'transfer' in: {msg}");
+    }
+
+    #[test]
+    fn transfer_fails_when_registry_is_missing() {
+        let cmd = Commands::Transfer {
+            name: "test.xlm".to_string(),
+            new_owner: "GDRANEW".to_string(),
+            signer: None,
+        };
+        let result =
+            validate_contract_policy(&cmd, &ContractOverrides::default(), &config_with_no_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registry-contract-id"),
+            "expected registry-contract-id in: {msg}"
+        );
+    }
+
+    // --- quote ---
+
+    #[test]
+    fn quote_rejects_irrelevant_registry_flag() {
+        let cmd = Commands::Quote {
+            name: "test".to_string(),
+            years: 1,
+        };
+        let overrides = ContractOverrides {
+            registry_contract_id: Some("REGISTRY111".to_string()),
+            ..Default::default()
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_all_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registry-contract-id"),
+            "expected registry-contract-id in: {msg}"
+        );
+        assert!(msg.contains("quote"), "expected 'quote' in: {msg}");
+    }
+
+    // --- availability ---
+
+    #[test]
+    fn availability_rejects_irrelevant_registrar_flag() {
+        let cmd = Commands::Availability {
+            name: "test.xlm".to_string(),
+        };
+        let overrides = ContractOverrides {
+            registrar_contract_id: Some("REGISTRAR111".to_string()),
+            ..Default::default()
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_all_contracts());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("registrar-contract-id"),
+            "expected registrar-contract-id in: {msg}"
+        );
+    }
+
+    #[test]
+    fn availability_passes_with_no_contracts_configured() {
+        let cmd = Commands::Availability {
+            name: "test.xlm".to_string(),
+        };
+        let result = validate_contract_policy(
+            &cmd,
+            &ContractOverrides::default(),
+            &config_with_no_contracts(),
+        );
+        assert!(
+            result.is_ok(),
+            "availability needs no required contracts: {:?}",
+            result.err()
+        );
+    }
+
+    // --- healthcheck ---
+
+    #[test]
+    fn healthcheck_allows_all_contract_flags() {
+        let cmd = Commands::Healthcheck;
+        let overrides = ContractOverrides {
+            registry_contract_id: Some("REGISTRY111".to_string()),
+            registrar_contract_id: Some("REGISTRAR111".to_string()),
+            resolver_contract_id: Some("RESOLVER111".to_string()),
+            auction_contract_id: Some("AUCTION111".to_string()),
+            bridge_contract_id: Some("BRIDGE111".to_string()),
+            subdomain_contract_id: Some("SUBDOMAIN111".to_string()),
+            nft_contract_id: Some("NFT111".to_string()),
+        };
+        let result = validate_contract_policy(&cmd, &overrides, &config_with_no_contracts());
+        assert!(
+            result.is_ok(),
+            "healthcheck should accept any contract flag: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn healthcheck_passes_with_no_contracts_configured() {
+        let cmd = Commands::Healthcheck;
+        let result = validate_contract_policy(
+            &cmd,
+            &ContractOverrides::default(),
+            &config_with_no_contracts(),
+        );
+        assert!(
+            result.is_ok(),
+            "healthcheck requires no contracts: {:?}",
+            result.err()
+        );
     }
 }
 
@@ -531,6 +821,21 @@ fn validate_contract_policy(
             &[ContractKind::Registrar],
         ),
         Commands::Availability { .. } => ("availability", &[ContractKind::Registry], &[]),
+        // Healthcheck is purely informational: all contract flags are allowed
+        // (they are reflected in the output) and none are required.
+        Commands::Healthcheck => (
+            "healthcheck",
+            &[
+                ContractKind::Registry,
+                ContractKind::Registrar,
+                ContractKind::Resolver,
+                ContractKind::Auction,
+                ContractKind::Bridge,
+                ContractKind::Subdomain,
+                ContractKind::Nft,
+            ],
+            &[],
+        ),
     };
 
     for kind in overrides.provided_kinds() {

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -192,6 +192,10 @@ impl RegistryContract {
         put_entry(&env, &name, &entry);
         remove_owner_name(&env, &old_owner, &name);
         add_owner_name(&env, &new_owner, &name);
+        env.events().publish(
+            (symbol_short!("name"), symbol_short!("transfer")),
+            (name, old_owner, new_owner),
+        );
         Ok(())
     }
 
@@ -284,6 +288,36 @@ impl RegistryContract {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Returns names present in the owner index that are inconsistent with
+    /// persistent storage — either the entry is missing, or its owner field
+    /// does not match the queried address.
+    ///
+    /// A consistent registry always returns an empty vec. Non-empty results
+    /// indicate that an external write bypassed the normal registration flow
+    /// (e.g. a storage migration gone wrong) and should be investigated before
+    /// proceeding.
+    pub fn audit_owner_index(env: Env, owner: Address) -> Vec<String> {
+        let indexed_names: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerNames(owner.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        let mut stale = Vec::new(&env);
+        for name in indexed_names.iter() {
+            match env
+                .storage()
+                .persistent()
+                .get::<_, RegistryEntry>(&DataKey::Entry(name.clone()))
+            {
+                None => stale.push_back(name),
+                Some(entry) if entry.owner != owner => stale.push_back(name),
+                _ => {}
+            }
+        }
+        stale
+    }
+
     pub fn burn(
         env: Env,
         name: String,
@@ -313,6 +347,23 @@ impl RegistryContract {
 
     pub fn supports_admin_recovery(_env: Env) -> bool {
         ADMIN_RECOVERY_SUPPORTED
+    }
+}
+
+/// Inserts `name` into `owner`'s index without creating a corresponding
+/// registry entry. Call only from tests to simulate an inconsistent state
+/// that `audit_owner_index` should detect.
+#[cfg(test)]
+pub fn inject_stale_index_entry(env: &Env, owner: &Address, name: &String) {
+    let key = DataKey::OwnerNames(owner.clone());
+    let mut names: Vec<String> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    if !names.contains(name) {
+        names.push_back(name.clone());
+        env.storage().persistent().set(&key, &names);
     }
 }
 

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -1,8 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use soroban_sdk::{testutils::Address as _, testutils::Events as _, Address, Env, String};
 
-    use crate::{NameState, RegistryContract, RegistryContractClient, RegistryError};
+    use crate::{
+        inject_stale_index_entry, NameState, RegistryContract, RegistryContractClient,
+        RegistryError,
+    };
 
     struct TimeHelper {
         pub now: u64,
@@ -452,5 +455,217 @@ mod tests {
         let client = RegistryContractClient::new(&env, &contract_id);
 
         assert!(!client.supports_admin_recovery());
+    }
+
+    // ---- issue #303: owner-index audit helper ----
+
+    #[test]
+    fn audit_owner_index_is_empty_for_consistent_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let name = String::from_str(&env, "audit-ok.xlm");
+        let time = TimeHelper::new();
+
+        client.register(
+            &name,
+            &owner,
+            &None::<String>,
+            &None::<String>,
+            &time.now,
+            &time.future(1_000),
+            &time.future(2_000),
+        );
+
+        let stale = client.audit_owner_index(&owner);
+        assert_eq!(stale.len(), 0, "expected no stale entries after normal registration");
+    }
+
+    #[test]
+    fn audit_owner_index_is_empty_after_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let next_owner = Address::generate(&env);
+        let name = String::from_str(&env, "audit-xfer.xlm");
+        let time = TimeHelper::new();
+
+        client.register(
+            &name,
+            &owner,
+            &None::<String>,
+            &None::<String>,
+            &time.now,
+            &time.future(1_000),
+            &time.future(2_000),
+        );
+        client.transfer(&name, &owner, &next_owner, &time.future(10));
+
+        // Both old and new owner indices must be consistent after transfer.
+        assert_eq!(
+            client.audit_owner_index(&owner).len(),
+            0,
+            "previous owner index should be clean after transfer"
+        );
+        assert_eq!(
+            client.audit_owner_index(&next_owner).len(),
+            0,
+            "new owner index should be clean after transfer"
+        );
+    }
+
+    #[test]
+    fn audit_owner_index_is_empty_for_unknown_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let stranger = Address::generate(&env);
+        let stale = client.audit_owner_index(&stranger);
+        assert_eq!(stale.len(), 0, "unknown owner should have an empty audit result");
+    }
+
+    #[test]
+    fn audit_owner_index_detects_stale_index_entry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let phantom = String::from_str(&env, "phantom.xlm");
+
+        // Inject an index entry that has no backing registry entry, simulating
+        // the kind of inconsistency that a failed storage migration could leave.
+        env.as_contract(&contract_id, || {
+            inject_stale_index_entry(&env, &owner, &phantom);
+        });
+
+        let stale = client.audit_owner_index(&owner);
+        assert_eq!(stale.len(), 1, "expected exactly one stale entry");
+        assert_eq!(stale.get(0).unwrap(), phantom);
+    }
+
+    // ---- issue #304: transfer event schema ----
+    //
+    // The transfer event schema is:
+    //   topics: ("name", "transfer")
+    //   data:   (name: String, old_owner: Address, new_owner: Address)
+    //
+    // Indexers that subscribe to the registry contract can rely on this layout
+    // to track ownership changes.
+
+    #[test]
+    fn transfer_emits_event_with_name_old_owner_and_new_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let next_owner = Address::generate(&env);
+        let name = String::from_str(&env, "event-xfer.xlm");
+        let time = TimeHelper::new();
+
+        client.register(
+            &name,
+            &owner,
+            &None::<String>,
+            &None::<String>,
+            &time.now,
+            &time.future(1_000),
+            &time.future(2_000),
+        );
+
+        client.transfer(&name, &owner, &next_owner, &time.future(10));
+
+        // Verify the exact event schema so indexers can depend on a stable layout.
+        use soroban_sdk::IntoVal;
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![
+                &env,
+                (
+                    contract_id.clone(),
+                    (
+                        soroban_sdk::symbol_short!("name"),
+                        soroban_sdk::symbol_short!("transfer"),
+                    )
+                        .into_val(&env),
+                    (name.clone(), owner.clone(), next_owner.clone()).into_val(&env),
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn transfer_event_is_emitted_once_per_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistryContract, ());
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let second = Address::generate(&env);
+        let third = Address::generate(&env);
+        let name = String::from_str(&env, "multi-xfer.xlm");
+        let time = TimeHelper::new();
+
+        client.register(
+            &name,
+            &owner,
+            &None::<String>,
+            &None::<String>,
+            &time.now,
+            &time.future(10_000),
+            &time.future(20_000),
+        );
+
+        // Verify each transfer individually — Soroban's testutils scope events
+        // per invocation, so we check the schema after each call.
+        use soroban_sdk::IntoVal;
+
+        client.transfer(&name, &owner, &second, &time.future(10));
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![
+                &env,
+                (
+                    contract_id.clone(),
+                    (
+                        soroban_sdk::symbol_short!("name"),
+                        soroban_sdk::symbol_short!("transfer"),
+                    )
+                        .into_val(&env),
+                    (name.clone(), owner.clone(), second.clone()).into_val(&env),
+                ),
+            ],
+            "first transfer event should carry (name, old_owner, new_owner)"
+        );
+
+        client.transfer(&name, &second, &third, &time.future(20));
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![
+                &env,
+                (
+                    contract_id.clone(),
+                    (
+                        soroban_sdk::symbol_short!("name"),
+                        soroban_sdk::symbol_short!("transfer"),
+                    )
+                        .into_val(&env),
+                    (name.clone(), second.clone(), third.clone()).into_val(&env),
+                ),
+            ],
+            "second transfer event should carry (name, old_owner, new_owner)"
+        );
     }
 }

--- a/contracts/registry/test_snapshots/test/tests/audit_owner_index_detects_stale_index_entry.1.json
+++ b/contracts/registry/test_snapshots/test/tests/audit_owner_index_detects_stale_index_entry.1.json
@@ -1,0 +1,93 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "phantom.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/registry/test_snapshots/test/tests/audit_owner_index_is_empty_after_transfer.1.json
+++ b/contracts/registry/test_snapshots/test/tests/audit_owner_index_is_empty_after_transfer.1.json
@@ -1,0 +1,323 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "string": "audit-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "void",
+                "void",
+                {
+                  "u64": "100000"
+                },
+                {
+                  "u64": "101000"
+                },
+                {
+                  "u64": "102000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "string": "audit-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "100010"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Entry"
+                  },
+                  {
+                    "string": "audit-xfer.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": {
+                      "u64": "101000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grace_period_ends_at"
+                    },
+                    "val": {
+                      "u64": "102000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "metadata_uri"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "audit-xfer.xlm"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registered_at"
+                    },
+                    "val": {
+                      "u64": "100000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "resolver"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "target_address"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "transfer_count"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "ttl_seconds"
+                    },
+                    "val": {
+                      "u64": "31536000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "audit-xfer.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/registry/test_snapshots/test/tests/audit_owner_index_is_empty_for_consistent_state.1.json
+++ b/contracts/registry/test_snapshots/test/tests/audit_owner_index_is_empty_for_consistent_state.1.json
@@ -1,0 +1,247 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "string": "audit-ok.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "void",
+                "void",
+                {
+                  "u64": "100000"
+                },
+                {
+                  "u64": "101000"
+                },
+                {
+                  "u64": "102000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Entry"
+                  },
+                  {
+                    "string": "audit-ok.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": {
+                      "u64": "101000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grace_period_ends_at"
+                    },
+                    "val": {
+                      "u64": "102000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "metadata_uri"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "audit-ok.xlm"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registered_at"
+                    },
+                    "val": {
+                      "u64": "100000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "resolver"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "target_address"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "transfer_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "ttl_seconds"
+                    },
+                    "val": {
+                      "u64": "31536000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "audit-ok.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/registry/test_snapshots/test/tests/audit_owner_index_is_empty_for_unknown_owner.1.json
+++ b/contracts/registry/test_snapshots/test/tests/audit_owner_index_is_empty_for_unknown_owner.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/registry/test_snapshots/test/tests/name_state_distinguishes_lifecycle_phases.1.json
+++ b/contracts/registry/test_snapshots/test/tests/name_state_distinguishes_lifecycle_phases.1.json
@@ -1,0 +1,252 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "string": "phase.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "void",
+                "void",
+                {
+                  "u64": "100000"
+                },
+                {
+                  "u64": "101000"
+                },
+                {
+                  "u64": "102000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Entry"
+                  },
+                  {
+                    "string": "phase.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": {
+                      "u64": "101000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grace_period_ends_at"
+                    },
+                    "val": {
+                      "u64": "102000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "metadata_uri"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "phase.xlm"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registered_at"
+                    },
+                    "val": {
+                      "u64": "100000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "resolver"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "target_address"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "transfer_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "ttl_seconds"
+                    },
+                    "val": {
+                      "u64": "31536000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "phase.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/registry/test_snapshots/test/tests/transfer_emits_event_with_name_old_owner_and_new_owner.1.json
+++ b/contracts/registry/test_snapshots/test/tests/transfer_emits_event_with_name_old_owner_and_new_owner.1.json
@@ -1,0 +1,355 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "string": "event-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "void",
+                "void",
+                {
+                  "u64": "100000"
+                },
+                {
+                  "u64": "101000"
+                },
+                {
+                  "u64": "102000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "string": "event-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "100010"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Entry"
+                  },
+                  {
+                    "string": "event-xfer.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": {
+                      "u64": "101000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grace_period_ends_at"
+                    },
+                    "val": {
+                      "u64": "102000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "metadata_uri"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "event-xfer.xlm"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registered_at"
+                    },
+                    "val": {
+                      "u64": "100000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "resolver"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "target_address"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "transfer_count"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "ttl_seconds"
+                    },
+                    "val": {
+                      "u64": "31536000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "event-xfer.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "name"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "event-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/registry/test_snapshots/test/tests/transfer_event_is_emitted_once_per_transfer.1.json
+++ b/contracts/registry/test_snapshots/test/tests/transfer_event_is_emitted_once_per_transfer.1.json
@@ -1,0 +1,430 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "string": "multi-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "void",
+                "void",
+                {
+                  "u64": "100000"
+                },
+                {
+                  "u64": "110000"
+                },
+                {
+                  "u64": "120000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "string": "multi-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "100010"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "string": "multi-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "100020"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Entry"
+                  },
+                  {
+                    "string": "multi-xfer.xlm"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": {
+                      "u64": "110000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grace_period_ends_at"
+                    },
+                    "val": {
+                      "u64": "120000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "metadata_uri"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "multi-xfer.xlm"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registered_at"
+                    },
+                    "val": {
+                      "u64": "100000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "resolver"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "target_address"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "transfer_count"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "ttl_seconds"
+                    },
+                    "val": {
+                      "u64": "31536000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "OwnerNames"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "string": "multi-xfer.xlm"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "name"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "multi-xfer.xlm"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
closes #301, closes #302, closes #303, closes #304

## Summary

### #301 — RPC and contract healthcheck command

Adds `xlm-ns healthcheck`, a read-only command that verifies RPC
connectivity, the configured network passphrase, and reports the
configuration status of all seven contract IDs. The command exits with a
non-zero status when any check fails so it can be used in health-probe
scripts and CI pipelines.

- New file: `cli/src/commands/healthcheck.rs`
- `Healthcheck` variant added to `Commands` and to `validate_contract_policy`
  (all contract flags allowed, none required)
- Both `--output human` and `--output json` are supported

### #302 — CLI tests for invalid contract flag combinations

Adds a `#[cfg(test)]` module to `cli/src/main.rs` that exercises
`validate_contract_policy` directly. Tests cover:

- Irrelevant contract flags rejected for `register`, `resolve`,
  `transfer`, `quote`, and `availability`
- Missing required contracts produce actionable error messages that
  name the expected flag and env var
- `availability` and `healthcheck` pass with no contracts configured
- Success paths (only the allowed flag, correct contract present)

### #303 — Registry owner-index audit helper for migrations

Adds `RegistryContract::audit_owner_index(env, owner) -> Vec<String>` to
`contracts/registry/src/lib.rs`. The function returns names present in an
owner's index that are inconsistent with persistent storage (entry missing
or owner field mismatch). A consistent registry always returns an empty
vec; a non-empty result indicates that an external write — such as a
failed storage migration — bypassed the normal registration flow.

Tests (in `contracts/registry/src/test.rs`):

- Clean state after registration returns empty result
- Both owner indices are consistent after a transfer
- Unknown owner returns empty result
- A manually injected stale index entry is detected (`env.as_contract`
  + test-only `inject_stale_index_entry` helper)

### #304 — Registry transfer event schema tests

Adds a `("name", "transfer")` Soroban event to
`RegistryContract::transfer`, emitted after every successful ownership
change with data `(name: String, old_owner: Address, new_owner: Address)`.

Tests verify the exact event payload schema using `assert_eq!` against the
full expected event vector, ensuring indexers can rely on a stable layout:

- `transfer_emits_event_with_name_old_owner_and_new_owner` — schema
  correctness for a single transfer
- `transfer_event_is_emitted_once_per_transfer` — one event per ownership
  change, schema verified for two sequential transfers

## Notes

- All 20 registry unit tests pass.
- The CLI type-checks cleanly (`cargo check -p xlm-ns-cli --tests` exit 0);
  `cargo test -p xlm-ns-cli` is blocked by a pre-existing compile error in
  `xlm-ns-auction` (`MAX_PAGE_SIZE` / `AuctionIndex` undefined) that
  predates this branch.
- The three `env.events().publish` deprecation warnings in
  `contracts/registry/src/lib.rs` are pre-existing (two from `register`
  and `burn`); the new transfer event adds a third. Migration to the
  `#[contractevent]` macro is a separate task.
- Soroban SDK 26.x automatically writes test snapshot JSON files under
  `contracts/registry/test_snapshots/`; these are committed alongside the
  tests.
