### PR TITLE
Shared time helpers, bridge reverse payloads, and storage versioning

### DIFF
--- a/contracts/auction/src/lib.rs
+++ b/contracts/auction/src/lib.rs
@@ -1,7 +1,10 @@
 mod test;
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec, token};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, String, Vec,
+};
 use xlm_ns_common::soroban::validate_fqdn_soroban;
+use xlm_ns_common::time::is_time_window_open;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -45,6 +48,7 @@ enum DataKey {
 
 /// Bounded result window for auction discovery queries (#157).
 const MAX_AUCTION_RESULTS: u32 = 100;
+const MAX_PAGE_SIZE: u32 = MAX_AUCTION_RESULTS;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -98,7 +102,9 @@ impl AuctionContract {
             .get(&DataKey::AuctionNames)
             .unwrap_or_else(|| Vec::new(&env));
         names.push_back(name.clone());
-        env.storage().persistent().set(&DataKey::AuctionNames, &names);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AuctionNames, &names);
         Ok(())
     }
 
@@ -132,7 +138,7 @@ impl AuctionContract {
                 continue;
             }
             if let Some(auction) = Self::auction(env.clone(), name.clone()) {
-                if now_unix >= auction.starts_at && now_unix <= auction.ends_at {
+                if is_time_window_open(now_unix, auction.starts_at, auction.ends_at) {
                     out.push_back(auction);
                 }
             }
@@ -177,10 +183,10 @@ impl AuctionContract {
         {
             return Err(AuctionError::AlreadySettled);
         }
-        if now_unix < auction.starts_at {
-            return Err(AuctionError::AuctionNotStarted);
-        }
-        if now_unix > auction.ends_at {
+        if !is_time_window_open(now_unix, auction.starts_at, auction.ends_at) {
+            if now_unix < auction.starts_at {
+                return Err(AuctionError::AuctionNotStarted);
+            }
             return Err(AuctionError::AuctionClosed);
         }
 
@@ -231,13 +237,25 @@ impl AuctionContract {
                     clearing_price_paid = true;
                     let overpay = bid.amount.saturating_sub(finalized.clearing_price);
                     if overpay > 0 {
-                        token.transfer(&env.current_contract_address(), &bid.bidder, &(overpay as i128));
+                        token.transfer(
+                            &env.current_contract_address(),
+                            &bid.bidder,
+                            &(overpay as i128),
+                        );
                     }
                     if finalized.clearing_price > 0 {
-                        token.transfer(&env.current_contract_address(), &auction.treasury, &(finalized.clearing_price as i128));
+                        token.transfer(
+                            &env.current_contract_address(),
+                            &auction.treasury,
+                            &(finalized.clearing_price as i128),
+                        );
                     }
                 } else {
-                    token.transfer(&env.current_contract_address(), &bid.bidder, &(bid.amount as i128));
+                    token.transfer(
+                        &env.current_contract_address(),
+                        &bid.bidder,
+                        &(bid.amount as i128),
+                    );
                 }
             }
         }
@@ -297,7 +315,7 @@ impl AuctionContract {
 fn auction_index(env: &Env) -> Vec<String> {
     env.storage()
         .persistent()
-        .get(&DataKey::AuctionIndex)
+        .get(&DataKey::AuctionNames)
         .unwrap_or_else(|| Vec::new(env))
 }
 
@@ -306,7 +324,7 @@ fn append_auction_name(env: &Env, name: &String) {
     index.push_back(name.clone());
     env.storage()
         .persistent()
-        .set(&DataKey::AuctionIndex, &index);
+        .set(&DataKey::AuctionNames, &index);
 }
 
 fn slice_index(env: &Env, index: &Vec<String>, offset: u32, limit: u32) -> Vec<String> {

--- a/contracts/bridge/src/axelar.rs
+++ b/contracts/bridge/src/axelar.rs
@@ -1,7 +1,22 @@
-pub fn build_gmp_message(name: &str, destination_chain: &str, resolver: &str) -> String {
+pub fn build_forward_gmp_message(
+    name: &impl core::fmt::Display,
+    destination_chain: &impl core::fmt::Display,
+    resolver: &impl core::fmt::Display,
+) -> String {
     format!(
         "{{\"type\":\"xlm-ns-resolution\",\"name\":\"{}\",\"destination_chain\":\"{}\",\"resolver\":\"{}\"}}",
         name, destination_chain, resolver
     )
 }
-//oo
+
+pub fn build_reverse_gmp_message(
+    address: &impl core::fmt::Display,
+    primary_name: &impl core::fmt::Display,
+    destination_chain: &impl core::fmt::Display,
+    resolver: &impl core::fmt::Display,
+) -> String {
+    format!(
+        "{{\"type\":\"xlm-ns-reverse-resolution\",\"address\":\"{}\",\"primary_name\":\"{}\",\"destination_chain\":\"{}\",\"resolver\":\"{}\"}}",
+        address, primary_name, destination_chain, resolver
+    )
+}

--- a/contracts/bridge/src/lib.rs
+++ b/contracts/bridge/src/lib.rs
@@ -1,3 +1,4 @@
+mod axelar;
 mod test;
 
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Env, String};
@@ -57,9 +58,35 @@ impl BridgeContract {
             .get(&DataKey::Route(chain.clone()))
             .ok_or(BridgeError::UnsupportedChain)?;
 
-        Ok(build_gmp_message(
+        Ok(build_forward_gmp_message(
             &env,
             &name,
+            &route.destination_chain,
+            &route.destination_resolver,
+        ))
+    }
+
+    pub fn build_reverse_message(
+        env: Env,
+        address: String,
+        primary_name: String,
+        chain: String,
+    ) -> Result<String, BridgeError> {
+        if address.len() == 0 || primary_name.len() == 0 {
+            return Err(BridgeError::Validation);
+        }
+        validate_fqdn_soroban(&primary_name).map_err(|_| BridgeError::Validation)?;
+        validate_chain_name_soroban(&chain).map_err(|_| BridgeError::Validation)?;
+        let route: BridgeRoute = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Route(chain.clone()))
+            .ok_or(BridgeError::UnsupportedChain)?;
+
+        Ok(build_reverse_gmp_message(
+            &env,
+            &address,
+            &primary_name,
             &route.destination_chain,
             &route.destination_resolver,
         ))
@@ -98,15 +125,27 @@ fn target_for_chain(env: &Env, chain: &String) -> Option<BridgeRoute> {
     }
 }
 
-fn build_gmp_message(
+fn build_forward_gmp_message(
     env: &Env,
     name: &String,
     destination_chain: &String,
     resolver: &String,
 ) -> String {
-    let message = format!(
-        "{{\"type\":\"xlm-ns-resolution\",\"name\":\"{}\",\"destination_chain\":\"{}\",\"resolver\":\"{}\"}}",
-        name, destination_chain, resolver
-    );
-    String::from_str(env, &message)
+    String::from_str(
+        env,
+        &axelar::build_forward_gmp_message(name, destination_chain, resolver),
+    )
+}
+
+fn build_reverse_gmp_message(
+    env: &Env,
+    address: &String,
+    primary_name: &String,
+    destination_chain: &String,
+    resolver: &String,
+) -> String {
+    String::from_str(
+        env,
+        &axelar::build_reverse_gmp_message(address, primary_name, destination_chain, resolver),
+    )
 }

--- a/contracts/registrar/src/expiry.rs
+++ b/contracts/registrar/src/expiry.rs
@@ -1,11 +1,1 @@
-use xlm_ns_common::GRACE_PERIOD_SECONDS;
-
-const YEAR_SECONDS: u64 = 31_536_000;
-
-pub fn expiry_from_now(now_unix: u64, years: u64) -> u64 {
-    now_unix.saturating_add(YEAR_SECONDS.saturating_mul(years))
-}
-
-pub fn within_grace_period(expiry_unix: u64, now_unix: u64) -> bool {
-    now_unix > expiry_unix && now_unix <= expiry_unix.saturating_add(GRACE_PERIOD_SECONDS)
-}
+pub use xlm_ns_common::time::{expiry_from_now, grace_period_ends_at, within_grace_period};

--- a/contracts/registrar/src/lib.rs
+++ b/contracts/registrar/src/lib.rs
@@ -5,13 +5,14 @@ mod test;
 use expiry::expiry_from_now;
 use pricing::price_for_label_length;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, IntoVal,
+    String, Symbol, Vec,
 };
 use xlm_ns_common::soroban::{
     build_xlm_name, extract_label_soroban, validate_label_soroban,
     validate_registration_years_soroban,
 };
-use xlm_ns_common::GRACE_PERIOD_SECONDS;
+use xlm_ns_common::time::grace_period_ends_at;
 
 pub const ADMIN_RECOVERY_SUPPORTED: bool = false;
 
@@ -122,17 +123,18 @@ impl RegistrarContract {
     pub fn reserve_label(env: Env, label: String) -> Result<(), RegistrarError> {
         validate_label_soroban(&label).map_err(|_| RegistrarError::Validation)?;
         let key = DataKey::Reserved(label.clone());
-        if env.storage().persistent().get::<_, bool>(&key).unwrap_or(false) {
-            env.events().publish(
-                (symbol_short!("reserved"), symbol_short!("skipped")),
-                label,
-            );
+        if env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&key)
+            .unwrap_or(false)
+        {
+            env.events()
+                .publish((symbol_short!("reserved"), symbol_short!("skipped")), label);
         } else {
             env.storage().persistent().set(&key, &true);
-            env.events().publish(
-                (symbol_short!("reserved"), symbol_short!("added")),
-                label,
-            );
+            env.events()
+                .publish((symbol_short!("reserved"), symbol_short!("added")), label);
         }
         Ok(())
     }
@@ -142,18 +144,29 @@ impl RegistrarContract {
         for label in labels.iter() {
             if validate_label_soroban(&label).is_ok() {
                 let key = DataKey::Reserved(label.clone());
-                if env.storage().persistent().get::<_, bool>(&key).unwrap_or(false) {
+                if env
+                    .storage()
+                    .persistent()
+                    .get::<_, bool>(&key)
+                    .unwrap_or(false)
+                {
                     env.events().publish(
                         (symbol_short!("reserved"), symbol_short!("skipped")),
                         label.clone(),
                     );
                 } else {
                     env.storage().persistent().set(&key, &true);
-                    env.events().publish((symbol_short!("reserved"), symbol_short!("added")), label.clone());
+                    env.events().publish(
+                        (symbol_short!("reserved"), symbol_short!("added")),
+                        label.clone(),
+                    );
                     added_count += 1;
                 }
             } else {
-                env.events().publish((symbol_short!("reserved"), symbol_short!("skipped")), label.clone());
+                env.events().publish(
+                    (symbol_short!("reserved"), symbol_short!("skipped")),
+                    label.clone(),
+                );
             }
         }
         Ok(added_count)
@@ -203,7 +216,7 @@ impl RegistrarContract {
             fee_stroops: annual_fee.saturating_mul(years),
             current_expiry_unix: record.expires_at,
             extended_expiry_unix,
-            grace_period_ends_at: extended_expiry_unix.saturating_add(GRACE_PERIOD_SECONDS),
+            grace_period_ends_at: grace_period_ends_at(extended_expiry_unix),
             pricing: PricingBreakdown {
                 annual_fee_stroops: annual_fee,
                 duration_years: years,
@@ -349,7 +362,7 @@ impl RegistrarContract {
         };
         let expires_at = expiry_from_now(base_time, years);
         record.expires_at = expires_at;
-        record.grace_period_ends_at = expires_at.saturating_add(GRACE_PERIOD_SECONDS);
+        record.grace_period_ends_at = grace_period_ends_at(expires_at);
         record.renewed_at = now_unix;
         record.fee_paid = record.fee_paid.saturating_add(payment_stroops);
         env.storage()
@@ -508,7 +521,7 @@ fn build_quote(label: &String, years: u64, now_unix: u64) -> RegistrationQuote {
     RegistrationQuote {
         fee_stroops: annual_fee.saturating_mul(years),
         expiry_unix,
-        grace_period_ends_at: expiry_unix.saturating_add(GRACE_PERIOD_SECONDS),
+        grace_period_ends_at: grace_period_ends_at(expiry_unix),
         pricing: PricingBreakdown {
             annual_fee_stroops: annual_fee,
             duration_years: years,
@@ -518,7 +531,7 @@ fn build_quote(label: &String, years: u64, now_unix: u64) -> RegistrationQuote {
 }
 
 pub fn can_renew(expiry_unix: u64, now_unix: u64) -> Result<bool, RegistrarError> {
-    let grace_period_end = expiry_unix.saturating_add(GRACE_PERIOD_SECONDS);
+    let grace_period_end = grace_period_ends_at(expiry_unix);
 
     if now_unix > grace_period_end {
         return Err(RegistrarError::RegistrationClaimable);

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -4,9 +4,11 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
 };
 use xlm_ns_common::soroban::validate_fqdn_soroban;
+use xlm_ns_common::time::{is_active_at, is_claimable_at};
 use xlm_ns_common::{DEFAULT_TTL_SECONDS, MAX_METADATA_URI_LENGTH};
 
 pub const ADMIN_RECOVERY_SUPPORTED: bool = false;
+pub const STORAGE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -25,11 +27,11 @@ pub struct RegistryEntry {
 
 impl RegistryEntry {
     fn is_active_at(&self, now_unix: u64) -> bool {
-        now_unix <= self.expires_at
+        is_active_at(self.expires_at, now_unix)
     }
 
     fn is_claimable_at(&self, now_unix: u64) -> bool {
-        now_unix > self.grace_period_ends_at
+        is_claimable_at(self.grace_period_ends_at, now_unix)
     }
 }
 
@@ -348,6 +350,13 @@ impl RegistryContract {
     pub fn supports_admin_recovery(_env: Env) -> bool {
         ADMIN_RECOVERY_SUPPORTED
     }
+
+    /// Returns the current persistent-storage schema version for upgrade
+    /// planning. Future migrations should branch on this value before
+    /// rewriting any derived indexes.
+    pub fn storage_schema_version(_env: Env) -> u32 {
+        STORAGE_SCHEMA_VERSION
+    }
 }
 
 /// Inserts `name` into `owner`'s index without creating a corresponding
@@ -397,7 +406,7 @@ fn validate_lifecycle_timestamps(
     expires_at: u64,
     grace_period_ends_at: u64,
 ) -> Result<(), RegistryError> {
-    if expires_at < now_unix {
+    if !is_active_at(expires_at, now_unix) {
         return Err(RegistryError::InvalidExpiry);
     }
 

--- a/docs/contributing-contracts.md
+++ b/docs/contributing-contracts.md
@@ -181,7 +181,28 @@ leave it alongside real tests.
 
 ---
 
-## 4. Required local commands
+## 4. Storage migration strategy
+
+Treat persistent storage as versioned data, even when the current layout is
+still at version 1. The pattern in this workspace is:
+
+- Add a version marker or migration hook in the contract that owns the
+  persistent state.
+- Route lifecycle and timestamp math through shared helpers so future schema
+  changes do not duplicate logic.
+- Keep compatibility shims small and explicit: if a storage layout changes,
+  the upgrade path should rebuild or repair the derived indexes before the new
+  version is considered active.
+
+The registry contract is the reference example because it owns both canonical
+entries and the owner index. Any future storage upgrade should repair that
+index before writing the new storage version marker. The current code exposes
+`storage_schema_version()` as the lightweight read-only hook for clients and
+upgrade tooling.
+
+---
+
+## 5. Required local commands
 
 Run these before pushing any contract change:
 
@@ -216,7 +237,7 @@ cargo install --locked soroban-cli
 
 ---
 
-## 5. CI expectations
+## 6. CI expectations
 
 | Job | What it checks | Blocks merge? |
 |-----|---------------|---------------|

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -34,6 +34,27 @@ Notes:
 - `chain` must be a valid chain identifier (validated on-chain) and must have been registered.
 - The returned message is deterministic for a given `(name, route)` pair.
 
+### `build_reverse_message(address, primary_name, chain) -> string`
+
+Returns a JSON string shaped like:
+
+```json
+{
+  "type": "xlm-ns-reverse-resolution",
+  "address": "<stellar_address>",
+  "primary_name": "<fqdn>",
+  "destination_chain": "<chain>",
+  "resolver": "<destination_resolver>"
+}
+```
+
+Notes:
+
+- `address` and `primary_name` must be non-empty.
+- `primary_name` must be a fully-qualified `.xlm` name (validated on-chain).
+- `chain` must be a valid chain identifier (validated on-chain) and must have been registered.
+- The returned message is deterministic for a given `(address, primary_name, route)` pair.
+
 ## Resolver
 
 ### `ResolutionRecord`

--- a/packages/xlm-ns-common/src/lib.rs
+++ b/packages/xlm-ns-common/src/lib.rs
@@ -1,15 +1,20 @@
 pub mod constants;
 pub mod errors;
 pub mod soroban;
+pub mod time;
 pub mod types;
 pub mod validation;
 
 pub use constants::{
     DEFAULT_TTL_SECONDS, GRACE_PERIOD_SECONDS, MAX_CHAIN_NAME_LENGTH, MAX_METADATA_URI_LENGTH,
-    MAX_NAME_LENGTH, MAX_REGISTRATION_YEARS, MAX_TEXT_RECORD_VALUE_LENGTH, MAX_TEXT_RECORDS,
+    MAX_NAME_LENGTH, MAX_REGISTRATION_YEARS, MAX_TEXT_RECORDS, MAX_TEXT_RECORD_VALUE_LENGTH,
     MIN_NAME_LENGTH, MIN_REGISTRATION_YEARS, YEAR_SECONDS,
 };
 pub use errors::CommonError;
+pub use time::{
+    expiry_from_now, grace_period_ends_at, is_active_at, is_claimable_at, is_time_window_open,
+    within_grace_period,
+};
 #[cfg(feature = "soroban")]
 pub use types::RegistryEntry;
 pub use types::{NameHash, NameRecord, Tld};

--- a/packages/xlm-ns-common/src/time.rs
+++ b/packages/xlm-ns-common/src/time.rs
@@ -1,0 +1,25 @@
+use crate::{GRACE_PERIOD_SECONDS, YEAR_SECONDS};
+
+pub fn expiry_from_now(now_unix: u64, years: u64) -> u64 {
+    now_unix.saturating_add(YEAR_SECONDS.saturating_mul(years))
+}
+
+pub fn grace_period_ends_at(expiry_unix: u64) -> u64 {
+    expiry_unix.saturating_add(GRACE_PERIOD_SECONDS)
+}
+
+pub fn is_active_at(expires_at: u64, now_unix: u64) -> bool {
+    now_unix <= expires_at
+}
+
+pub fn within_grace_period(expiry_unix: u64, now_unix: u64) -> bool {
+    now_unix > expiry_unix && now_unix <= grace_period_ends_at(expiry_unix)
+}
+
+pub fn is_claimable_at(grace_period_ends_at: u64, now_unix: u64) -> bool {
+    now_unix > grace_period_ends_at
+}
+
+pub fn is_time_window_open(now_unix: u64, starts_at: u64, ends_at: u64) -> bool {
+    now_unix >= starts_at && now_unix <= ends_at
+}

--- a/packages/xlm-ns-common/src/types.rs
+++ b/packages/xlm-ns-common/src/types.rs
@@ -1,3 +1,5 @@
+use crate::time::{grace_period_ends_at, is_active_at, is_claimable_at, within_grace_period};
+
 pub type NameHash = [u8; 32];
 
 #[cfg(feature = "soroban")]
@@ -64,15 +66,15 @@ impl NameRecord {
     }
 
     pub fn is_active_at(&self, now_unix: u64) -> bool {
-        now_unix <= self.expires_at
+        is_active_at(self.expires_at, now_unix)
     }
 
     pub fn is_in_grace_period(&self, now_unix: u64) -> bool {
-        now_unix > self.expires_at && now_unix <= self.grace_period_ends_at
+        within_grace_period(self.expires_at, now_unix)
     }
 
     pub fn is_claimable_at(&self, now_unix: u64) -> bool {
-        now_unix > self.grace_period_ends_at
+        is_claimable_at(self.grace_period_ends_at, now_unix)
     }
 
     pub fn set_owner(&mut self, owner: impl Into<String>) {
@@ -90,6 +92,10 @@ impl NameRecord {
     pub fn extend_expiry(&mut self, expires_at: u64, grace_period_ends_at: u64) {
         self.expires_at = expires_at;
         self.grace_period_ends_at = grace_period_ends_at;
+    }
+
+    pub fn next_grace_period_ends_at(expires_at: u64) -> u64 {
+        grace_period_ends_at(expires_at)
     }
 }
 


### PR DESCRIPTION
Centralize timestamp math in the shared common crate, add reverse-resolution bridge payload helpers, and expose a registry storage schema version hook with migration guidance.

Closes #160
Closes #164
Closes #159
Closes #148
