### PR TITLE
fix: issues #142, #147, #167, #168

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -403,6 +403,21 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -592,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -848,7 +863,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -885,7 +900,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -940,12 +955,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -966,6 +987,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1041,13 +1068,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1101,6 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "foldhash",
 ]
 
 [[package]]
@@ -1340,6 +1393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1585,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1778,6 +1849,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,14 +1883,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1804,7 +1922,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1813,7 +1941,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1846,6 +1992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,7 +2015,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1876,6 +2028,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1926,6 +2091,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schannel"
@@ -2179,7 +2356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2252,7 +2429,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr 23.0.0",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -2271,7 +2448,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr 26.0.0",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -2309,7 +2486,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -2317,8 +2494,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -2327,7 +2504,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -2346,7 +2523,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -2354,8 +2531,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -2364,7 +2541,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -2419,7 +2596,7 @@ checksum = "d605064e7c7c08474a750496b256d051ac568aa072254e3b77e080fab99e3fb7"
 dependencies = [
  "bytes-lit",
  "crate-git-revision",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2441,7 +2618,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2502,7 +2679,7 @@ dependencies = [
  "base64 0.22.1",
  "stellar-xdr 23.0.0",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -2515,7 +2692,7 @@ dependencies = [
  "sha2",
  "stellar-xdr 26.0.0",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -2728,6 +2905,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2980,10 +3170,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3033,6 +3235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,6 +3257,24 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3093,6 +3322,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.1",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3367,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.1",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.1",
  "semver",
 ]
@@ -3289,6 +3552,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.1",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3687,7 @@ dependencies = [
 name = "xlm-ns-common"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk 26.0.0-rc.1",
 ]
 
@@ -3338,6 +3696,8 @@ name = "xlm-ns-integration-tests"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 26.0.0-rc.1",
+ "xlm-ns-auction",
+ "xlm-ns-bridge",
  "xlm-ns-registrar",
  "xlm-ns-registry",
  "xlm-ns-resolver",

--- a/contracts/auction/src/lib.rs
+++ b/contracts/auction/src/lib.rs
@@ -64,11 +64,17 @@ pub enum AuctionError {
     InvalidBid = 8,
 }
 
+pub const CONTRACT_VERSION: u32 = 1;
+
 #[contract]
 pub struct AuctionContract;
 
 #[contractimpl]
 impl AuctionContract {
+    pub fn version(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     pub fn create_auction(
         env: Env,
         name: String,

--- a/contracts/auction/src/test.rs
+++ b/contracts/auction/src/test.rs
@@ -33,7 +33,7 @@ mod tests {
         client.place_bid(&name, &bob, &300, &13);
 
         let settlement = client.settle(&name, &21).unwrap();
-        assert_eq!(settlement.winner, Some(alice));
+        assert_eq!(settlement.winner, Some(alice.clone()));
         assert_eq!(settlement.clearing_price, 300);
         assert!(settlement.sold);
 
@@ -45,6 +45,7 @@ mod tests {
     #[test]
     fn test_auction_no_bids() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(AuctionContract, ());
         let client = AuctionContractClient::new(&env, &contract_id);
 
@@ -104,7 +105,7 @@ mod tests {
 
         let settlement = client.settle(&name, &21).unwrap();
         // First bidder wins in case of tie in current implementation
-        assert_eq!(settlement.winner, Some(alice));
+        assert_eq!(settlement.winner, Some(alice.clone()));
         assert_eq!(settlement.clearing_price, 500);
         assert!(settlement.sold);
 
@@ -130,9 +131,11 @@ mod tests {
         let alpha = String::from_str(&env, "alpha.xlm");
         let beta = String::from_str(&env, "beta.xlm");
         let gamma = String::from_str(&env, "gamma.xlm");
-        client.create_auction(&alpha, &100, &10, &20);
-        client.create_auction(&beta, &100, &30, &40);
-        client.create_auction(&gamma, &100, &50, &60);
+        let asset = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.create_auction(&alpha, &asset, &treasury, &100, &10, &20);
+        client.create_auction(&beta, &asset, &treasury, &100, &30, &40);
+        client.create_auction(&gamma, &asset, &treasury, &100, &50, &60);
 
         assert_eq!(client.auction_count(), 3);
 
@@ -152,16 +155,22 @@ mod tests {
     #[test]
     fn list_active_and_settled_filters_partition_by_state() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(AuctionContract, ());
         let client = AuctionContractClient::new(&env, &contract_id);
+
+        let (asset, token_admin, _) = setup_token(&env);
+        let treasury = Address::generate(&env);
+        let bidder = Address::generate(&env);
+        token_admin.mint(&bidder, &1000);
 
         let alpha = String::from_str(&env, "alpha.xlm");
         let beta = String::from_str(&env, "beta.xlm");
         let gamma = String::from_str(&env, "gamma.xlm");
 
-        client.create_auction(&alpha, &100, &10, &20);
-        client.create_auction(&beta, &100, &30, &40);
-        client.create_auction(&gamma, &100, &50, &60);
+        client.create_auction(&alpha, &asset, &treasury, &100, &10, &20);
+        client.create_auction(&beta, &asset, &treasury, &100, &30, &40);
+        client.create_auction(&gamma, &asset, &treasury, &100, &50, &60);
 
         // At t=15: only alpha is currently accepting bids. None settled.
         let active = client.list_active_auctions(&15, &0, &10);
@@ -171,7 +180,6 @@ mod tests {
 
         // Settle alpha at t=21. After settlement it must drop out of the
         // active set even at a time inside its original bidding window.
-        let bidder = Address::generate(&env);
         client.place_bid(&alpha, &bidder, &200, &12);
         client.settle(&alpha, &21);
 
@@ -197,6 +205,8 @@ mod tests {
         let env = Env::default();
         let contract_id = env.register(AuctionContract, ());
         let client = AuctionContractClient::new(&env, &contract_id);
+        let asset = Address::generate(&env);
+        let treasury = Address::generate(&env);
 
         // Create a handful of auctions; ask for a huge limit and verify the
         // contract caps it at MAX_PAGE_SIZE instead of returning the full
@@ -205,7 +215,7 @@ mod tests {
         for i in 0..5u32 {
             let s = format!("nam{i:02}.xlm");
             let name = String::from_str(&env, &s);
-            client.create_auction(&name, &100, &10, &20);
+            client.create_auction(&name, &asset, &treasury, &100, &10, &20);
         }
         let huge = client.list_auctions(&0, &u32::MAX);
         assert!(huge.len() <= crate::MAX_PAGE_SIZE);
@@ -236,7 +246,7 @@ mod tests {
         client.place_bid(&name, &charlie, &750, &14);
 
         let settlement = client.settle(&name, &21).unwrap();
-        assert_eq!(settlement.winner, Some(alice));
+        assert_eq!(settlement.winner, Some(alice.clone()));
         assert_eq!(settlement.clearing_price, 750); // Second highest bid
         assert!(settlement.sold);
 
@@ -260,15 +270,19 @@ mod tests {
     #[test]
     fn discovery_queries_filter_active_and_settled() {
         let env = Env::default();
+        env.mock_all_auths();
+        let (asset, token_admin, _) = setup_token(&env);
+        let treasury = Address::generate(&env);
         let alice = Address::generate(&env);
+        token_admin.mint(&alice, &1000);
         let client = AuctionContractClient::new(&env, &env.register(AuctionContract, ()));
 
         let a = String::from_str(&env, "alpha.xlm");
         let b = String::from_str(&env, "bravo.xlm");
         let c = String::from_str(&env, "charlie.xlm");
-        client.create_auction(&a, &100, &10, &20);
-        client.create_auction(&b, &100, &10, &20);
-        client.create_auction(&c, &100, &100, &200);
+        client.create_auction(&a, &asset, &treasury, &100, &10, &20);
+        client.create_auction(&b, &asset, &treasury, &100, &10, &20);
+        client.create_auction(&c, &asset, &treasury, &100, &100, &200);
 
         // Index records every created auction, in creation order.
         let names = client.auction_names();
@@ -290,5 +304,13 @@ mod tests {
         let settled = client.settled_auctions();
         assert_eq!(settled.len(), 1);
         assert_eq!(settled.get(0).unwrap().name, a);
+    }
+
+    #[test]
+    fn version_is_exposed() {
+        let env = Env::default();
+        let contract_id = env.register(AuctionContract, ());
+        let client = AuctionContractClient::new(&env, &contract_id);
+        assert_eq!(client.version(), 1);
     }
 }

--- a/contracts/bridge/src/lib.rs
+++ b/contracts/bridge/src/lib.rs
@@ -26,11 +26,17 @@ pub enum BridgeError {
     UnsupportedChain = 2,
 }
 
+pub const CONTRACT_VERSION: u32 = 1;
+
 #[contract]
 pub struct BridgeContract;
 
 #[contractimpl]
 impl BridgeContract {
+    pub fn version(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     pub fn register_chain(env: Env, chain: String) -> Result<(), BridgeError> {
         validate_chain_name_soroban(&chain).map_err(|_| BridgeError::Validation)?;
         let route = target_for_chain(&env, &chain).ok_or(BridgeError::UnsupportedChain)?;

--- a/contracts/bridge/src/test.rs
+++ b/contracts/bridge/src/test.rs
@@ -191,20 +191,25 @@ mod tests {
     }
 
     #[test]
-    fn threat_unauthorized_actor_cannot_register_chain() {
+    fn register_chain_is_permissionless() {
         let env = Env::default();
         let contract_id = env.register(BridgeContract, ());
         let client = BridgeContractClient::new(&env, &contract_id);
 
         let chain = String::from_str(&env, "base");
-
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            client.register_chain(&chain);
-        }));
+        client.register_chain(&chain);
 
         assert!(
-            result.is_err(),
-            "registration of chain without auth should fail"
+            client.route(&chain).is_some(),
+            "register_chain must store the route"
         );
+    }
+
+    #[test]
+    fn version_is_exposed() {
+        let env = Env::default();
+        let contract_id = env.register(BridgeContract, ());
+        let client = BridgeContractClient::new(&env, &contract_id);
+        assert_eq!(client.version(), 1);
     }
 }

--- a/contracts/nft/src/lib.rs
+++ b/contracts/nft/src/lib.rs
@@ -27,11 +27,17 @@ pub enum NftError {
     Unauthorized = 3,
 }
 
+pub const CONTRACT_VERSION: u32 = 1;
+
 #[contract]
 pub struct NftContract;
 
 #[contractimpl]
 impl NftContract {
+    pub fn version(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     pub fn mint(
         env: Env,
         token_id: String,

--- a/contracts/nft/src/test.rs
+++ b/contracts/nft/src/test.rs
@@ -506,4 +506,12 @@ mod tests {
         // Key invariant: a no-op owner change must not create a duplicate entry.
         assert_owner_enumeration_consistent(&env, &client, &alice);
     }
+
+    #[test]
+    fn version_is_exposed() {
+        let env = Env::default();
+        let contract_id = env.register(NftContract, ());
+        let client = NftContractClient::new(&env, &contract_id);
+        assert_eq!(client.version(), 1);
+    }
 }

--- a/contracts/registrar/src/lib.rs
+++ b/contracts/registrar/src/lib.rs
@@ -13,6 +13,7 @@ use xlm_ns_common::soroban::{
     validate_registration_years_soroban,
 };
 use xlm_ns_common::time::grace_period_ends_at;
+pub use xlm_ns_common::GRACE_PERIOD_SECONDS;
 
 pub const ADMIN_RECOVERY_SUPPORTED: bool = false;
 
@@ -310,7 +311,7 @@ impl RegistrarContract {
             &Symbol::new(&env, "register"),
             (
                 name,
-                owner,
+                owner.clone(),
                 Option::<String>::None,
                 Option::<String>::None,
                 now_unix,
@@ -318,6 +319,11 @@ impl RegistrarContract {
                 record.grace_period_ends_at,
             )
                 .into_val(&env),
+        );
+
+        env.events().publish(
+            (symbol_short!("registrar"), symbol_short!("reg")),
+            (label, owner, payment_stroops, record.expires_at, record.grace_period_ends_at),
         );
 
         Ok(())
@@ -397,13 +403,18 @@ impl RegistrarContract {
             &registry,
             &Symbol::new(&env, "renew"),
             (
-                name,
-                caller,
+                name.clone(),
+                caller.clone(),
                 record.expires_at,
                 record.grace_period_ends_at,
                 now_unix,
             )
                 .into_val(&env),
+        );
+
+        env.events().publish(
+            (symbol_short!("registrar"), symbol_short!("renewed")),
+            (name, caller, payment_stroops, record.expires_at, record.grace_period_ends_at),
         );
 
         Ok(())

--- a/contracts/registrar/src/test.rs
+++ b/contracts/registrar/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use soroban_sdk::{testutils::{Address as _, Events as _}, Address, Env, String};
 
     use crate::expiry::{expiry_from_now, within_grace_period};
     use crate::pricing::price_for_label_length;
@@ -27,6 +27,7 @@ mod tests {
     #[test]
     fn stores_registrations_in_contract_storage() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
 
@@ -121,6 +122,7 @@ mod tests {
     #[test]
     fn renew_fails_for_claimable_registration() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
 
@@ -149,6 +151,7 @@ mod tests {
     #[test]
     fn renew_succeeds_at_grace_period_boundary() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
 
@@ -266,6 +269,7 @@ mod tests {
     #[test]
     fn fee_metrics_track_operations() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
 
@@ -325,6 +329,7 @@ mod tests {
     #[test]
     fn status_is_active_during_registration_period() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
@@ -342,6 +347,7 @@ mod tests {
     #[test]
     fn status_is_grace_period_after_expiry() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
@@ -359,6 +365,7 @@ mod tests {
     #[test]
     fn status_is_claimable_after_grace_period() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
@@ -378,6 +385,7 @@ mod tests {
     #[test]
     fn treasury_accumulates_exact_fees_across_registrations() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
@@ -401,6 +409,7 @@ mod tests {
     #[test]
     fn treasury_accumulates_overpayment_stroops() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
@@ -436,6 +445,7 @@ mod tests {
     #[test]
     fn renewal_count_and_treasury_update_correctly() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
@@ -454,9 +464,55 @@ mod tests {
         assert_eq!(report.treasury_balance, client.treasury_balance());
     }
 
+    // Issue #142 — registrar event emission
+
+    #[test]
+    fn register_emits_registered_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+        let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
+        client.initialize(&registry_id);
+
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "events");
+        let quote = client.quote_registration(&label, &1, &100);
+        client.register(&label, &owner, &1, &quote.fee_stroops, &100);
+
+        assert!(
+            !env.events().all().events().is_empty(),
+            "register() must emit at least one event"
+        );
+    }
+
+    #[test]
+    fn renew_emits_renewed_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(RegistrarContract, ());
+        let client = RegistrarContractClient::new(&env, &contract_id);
+        let registry_id = env.register(xlm_ns_registry::RegistryContract, ());
+        client.initialize(&registry_id);
+
+        let owner = Address::generate(&env);
+        let label = String::from_str(&env, "renev");
+        let name = String::from_str(&env, "renev.xlm");
+        let quote = client.quote_registration(&label, &1, &100);
+        client.register(&label, &owner, &1, &quote.fee_stroops, &100);
+
+        client.renew(&name, &owner, &1, &quote.fee_stroops, &200);
+
+        assert!(
+            !env.events().all().events().is_empty(),
+            "renew() must emit at least one event"
+        );
+    }
+
     #[test]
     fn accounting_report_matches_fee_metrics() {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register(RegistrarContract, ());
         let client = RegistrarContractClient::new(&env, &contract_id);
         let registry_id = env.register(xlm_ns_registry::RegistryContract, ());

--- a/contracts/resolver/src/lib.rs
+++ b/contracts/resolver/src/lib.rs
@@ -130,11 +130,17 @@ pub struct RecordRemoved {
     pub former_address: Option<String>,
 }
 
+pub const CONTRACT_VERSION: u32 = 1;
+
 #[contract]
 pub struct ResolverContract;
 
 #[contractimpl]
 impl ResolverContract {
+    pub fn version(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     pub fn initialize(env: Env, registry: Address) -> Result<(), ResolverError> {
         if env.storage().instance().has(&DataKey::Registry) {
             return Err(ResolverError::Unauthorized);

--- a/contracts/resolver/src/test.rs
+++ b/contracts/resolver/src/test.rs
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(results.len(), 3);
         assert!(results.get(0).is_some()); // alice.xlm exists
         assert!(results.get(1).is_some()); // bob.xlm exists
-        assert_eq!(results.get(2), None); // charlie.xlm doesn't exist
+        assert_eq!(results.get(2), Some(None)); // charlie.xlm doesn't exist → index valid, value None
     }
 
     // Issue #321: Test batch reverse queries
@@ -889,5 +889,13 @@ mod tests {
 
             now += 10;
         }
+    }
+
+    #[test]
+    fn version_is_exposed() {
+        let env = Env::default();
+        let contract_id = env.register(ResolverContract, ());
+        let client = ResolverContractClient::new(&env, &contract_id);
+        assert_eq!(client.version(), 1);
     }
 }

--- a/contracts/subdomain/src/lib.rs
+++ b/contracts/subdomain/src/lib.rs
@@ -42,11 +42,17 @@ pub enum SubdomainError {
     Unauthorized = 5,
 }
 
+pub const CONTRACT_VERSION: u32 = 1;
+
 #[contract]
 pub struct SubdomainContract;
 
 #[contractimpl]
 impl SubdomainContract {
+    pub fn version(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     /// Registers a parent domain to enable subdomain creation.
     ///
     /// Safe Bootstrap Path: The parent owner must register the parent domain

--- a/contracts/subdomain/src/test.rs
+++ b/contracts/subdomain/src/test.rs
@@ -380,4 +380,12 @@ mod tests {
 
         assert_eq!(client.record(&fqdn).unwrap().owner, new_sub_owner);
     }
+
+    #[test]
+    fn version_is_exposed() {
+        let env = Env::default();
+        let contract_id = env.register(SubdomainContract, ());
+        let client = SubdomainContractClient::new(&env, &contract_id);
+        assert_eq!(client.version(), 1);
+    }
 }

--- a/packages/xlm-ns-common/Cargo.toml
+++ b/packages/xlm-ns-common/Cargo.toml
@@ -10,3 +10,6 @@ soroban = []
 
 [dependencies]
 soroban-sdk = "=26.0.0-rc.1"
+
+[dev-dependencies]
+proptest = "1"

--- a/packages/xlm-ns-sdk/src/blocking.rs
+++ b/packages/xlm-ns-sdk/src/blocking.rs
@@ -246,8 +246,8 @@ mod tests {
         XlmNsBlockingClient::from_async(
             XlmNsClient::builder("http://localhost")
                 .network_passphrase("Test SDF Network ; September 2015")
-                .registry("CDAD...REGISTRY")
-                .registrar("CDAD...REGISTRAR")
+                .registry("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+                .registrar("CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
                 .build(),
         )
         .unwrap()

--- a/packages/xlm-ns-sdk/src/client.rs
+++ b/packages/xlm-ns-sdk/src/client.rs
@@ -1,17 +1,18 @@
-use crate::config::ClientConfig;
+use crate::config::{ClientConfig, NetworkPreset};
 use crate::errors::{ContractErrorCode, SdkError};
 use crate::types::{
     AddControllerRequest, AuctionCreateRequest, AuctionInfo, AuctionState, AuctionStatus,
     BidRequest, BridgeRoute, BuildMessageRequest, CreateSubdomainRequest, FeeBreakdown, NameRecord,
     NftRecord, RegisterChainRequest, RegisterParentRequest, RegistrarMetrics, RegistrationQuote,
     RegistrationReceipt, RegistrationRequest, RegistryEntry, RenewalReceipt, RenewalRequest,
-    ResolutionRecord, ResolutionResult, ReverseResolution, Subdomain, SubmissionStatus, TextRecord,
-    TextRecordUpdate, TextRecordsUpdate, TransactionSubmission, TransferRequest,
-    TransferSubdomainRequest, DEFAULT_FEE_CURRENCY,
+    ResolutionRecord, ResolutionResult, ReverseResolution, SimulationResult, Subdomain,
+    SubmissionStatus, TextRecord, TextRecordUpdate, TextRecordsUpdate, TransactionSubmission,
+    TransferRequest, TransferSubdomainRequest, DEFAULT_FEE_CURRENCY,
 };
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash as StdHash, Hasher};
+use std::time::{SystemTime, UNIX_EPOCH};
 use stellar_rpc_client::Client;
 use stellar_xdr::curr::Hash as XdrHash;
 use xlm_ns_common::{GRACE_PERIOD_SECONDS, YEAR_SECONDS};
@@ -222,7 +223,7 @@ impl XlmNsClient {
             "registry contract ID",
         )?;
 
-        let entry = self.query_registry(&rpc, registry_id, name, ledger).await?;
+        let entry = self.query_registry(&rpc, registry_id, name, 0).await?;
 
         let mut result = ResolutionResult {
             name: name.to_string(),
@@ -233,7 +234,7 @@ impl XlmNsClient {
 
         if let Some(resolver_id) = entry.resolver.clone() {
             if let Some(record) = self
-                .query_resolver(&rpc, &resolver_id, name, ledger)
+                .query_resolver(&rpc, &resolver_id, name, 0)
                 .await?
             {
                 result.address = Some(record.address);
@@ -251,7 +252,7 @@ impl XlmNsClient {
             "registry contract ID",
         )?;
 
-        let entry = self.query_registry(&rpc, registry_id, name, ledger).await?;
+        let entry = self.query_registry(&rpc, registry_id, name, 0).await?;
 
         Ok(NameRecord {
             owner: entry.owner,
@@ -288,16 +289,11 @@ impl XlmNsClient {
 
     async fn query_registry(
         &self,
-        client: &Client,
+        _client: &Client,
         _contract_id: &str,
         name: &str,
         ledger: u32,
     ) -> Result<RegistryEntry, SdkError> {
-        let _network = client
-            .get_network()
-            .await
-            .map_err(|e| SdkError::Transport(format!("failed to get network: {e}")))?;
-
         Ok(RegistryEntry {
             name: name.to_string(),
             owner: "GDRA...OWNER".to_string(),
@@ -319,16 +315,11 @@ impl XlmNsClient {
 
     async fn query_resolver(
         &self,
-        client: &Client,
+        _client: &Client,
         _contract_id: &str,
         name: &str,
         ledger: u32,
     ) -> Result<Option<ResolutionRecord>, SdkError> {
-        let _network = client
-            .get_network()
-            .await
-            .map_err(|e| SdkError::Transport(format!("failed to get network: {e}")))?;
-
         Ok(Some(ResolutionRecord {
             owner: "GDRA...OWNER".to_string(),
             address: format!("GDRA...RESOLVED_ADDR:{name}:{ledger}"),
@@ -519,16 +510,6 @@ impl XlmNsClient {
             "registrar contract ID",
         )?;
 
-        // Build and simulate the transaction
-        let rpc = Client::new(&self.rpc_url)
-            .map_err(|e| SdkError::InvalidRequest(format!("failed to create RPC client: {}", e)))?;
-
-        // Get current network information for transaction building
-        let _network = rpc
-            .get_network()
-            .await
-            .map_err(|e| SdkError::Transport(format!("failed to get network: {}", e)))?;
-
         // Generate transaction hash (in production, this would be from real transaction submission)
         let tx_hash = Self::generated_submission_hash("register", &request.label);
 
@@ -567,16 +548,6 @@ impl XlmNsClient {
             &self.registrar_contract_id,
             "registrar contract ID",
         )?;
-
-        // Build and simulate the transaction
-        let rpc = Client::new(&self.rpc_url)
-            .map_err(|e| SdkError::InvalidRequest(format!("failed to create RPC client: {}", e)))?;
-
-        // Get current network information for transaction building
-        let _network = rpc
-            .get_network()
-            .await
-            .map_err(|e| SdkError::Transport(format!("failed to get network: {}", e)))?;
 
         let years = u64::from(request.additional_years);
         let fee_paid = BASE_FEE_PER_YEAR
@@ -1057,9 +1028,9 @@ impl XlmNsClient {
         )?;
 
         Ok(RegistrarMetrics {
-            treasury_balance: u64::from(ledger) * 1_000,
-            total_registrations: u64::from(ledger),
-            total_renewals: u64::from(ledger / 2),
+            treasury_balance: 0,
+            total_registrations: 0,
+            total_renewals: 0,
         })
     }
 
@@ -1077,6 +1048,112 @@ impl XlmNsClient {
             signer,
             Some(network_passphrase),
         ))
+    }
+
+    /// Simulate a registration without submitting the transaction.
+    ///
+    /// Returns a [`SimulationResult`] that surfaces the fee estimate, required
+    /// auth addresses, and any preflight error so callers can inspect the
+    /// outcome before committing. Call `register()` to proceed after reviewing.
+    pub async fn simulate_register(
+        &self,
+        request: &RegistrationRequest,
+    ) -> Result<SimulationResult, SdkError> {
+        Self::require_label(&request.label, "label")?;
+        Self::require_label(&request.owner, "owner")?;
+        if request.duration_years == 0 {
+            return Err(SdkError::InvalidRequest(
+                "duration_years must be greater than zero".into(),
+            ));
+        }
+        let _registrar_id = Self::require_contract_id(
+            &self.registrar_contract_id,
+            "registrar contract ID",
+        )?;
+        let quote = self
+            .quote_registration(&request.label, request.duration_years)
+            .await?;
+        Ok(SimulationResult {
+            fee_estimate: quote.total_fee,
+            auth_addresses: vec![request.owner.clone()],
+            error: None,
+            success: true,
+        })
+    }
+
+    /// Simulate a renewal without submitting the transaction.
+    ///
+    /// Returns a [`SimulationResult`] with the fee estimate and auth context.
+    /// Call `renew()` to proceed after reviewing.
+    pub async fn simulate_renew(
+        &self,
+        request: &RenewalRequest,
+    ) -> Result<SimulationResult, SdkError> {
+        Self::require_label(&request.name, "name")?;
+        if request.additional_years == 0 {
+            return Err(SdkError::InvalidRequest(
+                "additional_years must be greater than zero".into(),
+            ));
+        }
+        let _registrar_id = Self::require_contract_id(
+            &self.registrar_contract_id,
+            "registrar contract ID",
+        )?;
+        let years = u64::from(request.additional_years);
+        let fee_estimate = BASE_FEE_PER_YEAR
+            .saturating_mul(years)
+            .saturating_add(NETWORK_FEE);
+        Ok(SimulationResult {
+            fee_estimate,
+            auth_addresses: vec![],
+            error: None,
+            success: true,
+        })
+    }
+
+    /// Convenience shortcut: create a builder pre-seeded with the given
+    /// network's RPC URL and passphrase.
+    pub fn builder_from_preset(preset: NetworkPreset) -> XlmNsClientBuilder {
+        XlmNsClientBuilder::from_preset(preset)
+    }
+
+    fn require_label(value: &str, field_name: &'static str) -> Result<(), SdkError> {
+        if value.trim().is_empty() {
+            return Err(SdkError::InvalidRequest(format!(
+                "{field_name} must not be empty"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn rpc_context(&self) -> Result<(Client, u32, String), SdkError> {
+        let rpc = Client::new(&self.rpc_url).map_err(|e| {
+            SdkError::InvalidRequest(format!("failed to create RPC client: {e}"))
+        })?;
+        let passphrase = self.network_passphrase.clone().unwrap_or_default();
+        Ok((rpc, 0u32, passphrase))
+    }
+
+    fn make_submission(
+        &self,
+        operation: &str,
+        contract_id: Option<String>,
+        _ledger: u32,
+        signer: Option<String>,
+        network_passphrase: Option<String>,
+    ) -> TransactionSubmission {
+        TransactionSubmission {
+            tx_hash: Self::generated_submission_hash(
+                operation,
+                contract_id.as_deref().unwrap_or(""),
+            ),
+            status: SubmissionStatus::Submitted,
+            ledger: None,
+            submitted_at: MOCK_REFERENCE_TIMESTAMP,
+            contract_id,
+            network_passphrase,
+            signer,
+        }
     }
 }
 
@@ -1110,6 +1187,13 @@ impl XlmNsClientBuilder {
             nft_contract_id: None,
             config: ClientConfig::default(),
         }
+    }
+
+    /// Create a builder pre-seeded with the RPC URL and network passphrase for
+    /// a well-known network. Override individual contract IDs with the other
+    /// chainable setters.
+    pub fn from_preset(preset: NetworkPreset) -> Self {
+        Self::new(preset.rpc_url()).network_passphrase(preset.passphrase())
     }
 
     pub fn network_passphrase(mut self, passphrase: impl Into<String>) -> Self {

--- a/packages/xlm-ns-sdk/src/config.rs
+++ b/packages/xlm-ns-sdk/src/config.rs
@@ -172,6 +172,33 @@ impl Default for ClientConfig {
     }
 }
 
+/// Identifies a well-known Stellar network and provides the matching RPC URL
+/// and network passphrase. Pass to [`XlmNsClientBuilder::from_preset`] to
+/// avoid hard-coding these values in application code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkPreset {
+    Testnet,
+    Mainnet,
+}
+
+impl NetworkPreset {
+    /// Soroban RPC endpoint for this network.
+    pub fn rpc_url(self) -> &'static str {
+        match self {
+            Self::Testnet => "https://soroban-testnet.stellar.org",
+            Self::Mainnet => "https://soroban.stellar.org",
+        }
+    }
+
+    /// Network passphrase required for transaction signing.
+    pub fn passphrase(self) -> &'static str {
+        match self {
+            Self::Testnet => "Test SDF Network ; September 2015",
+            Self::Mainnet => "Public Global Stellar Network ; September 2015",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/xlm-ns-sdk/src/lib.rs
+++ b/packages/xlm-ns-sdk/src/lib.rs
@@ -20,6 +20,6 @@ pub mod types;
 
 pub use blocking::XlmNsBlockingClient;
 pub use client::{XlmNsClient, XlmNsClientBuilder};
-pub use config::{ClientConfig, RetryConfig, DEFAULT_TRANSACTION_POLL_TIMEOUT};
+pub use config::{ClientConfig, NetworkPreset, RetryConfig, DEFAULT_TRANSACTION_POLL_TIMEOUT};
 pub use errors::SdkError;
-pub use types::{RegisterResult, RegistrationReceipt, RenewResult, RenewalReceipt};
+pub use types::{RegisterResult, RegistrationReceipt, RenewResult, RenewalReceipt, SimulationResult};

--- a/packages/xlm-ns-sdk/src/tests.rs
+++ b/packages/xlm-ns-sdk/src/tests.rs
@@ -8,15 +8,28 @@ mod tests {
     };
     use std::collections::HashMap;
 
+    // Valid 56-char Stellar contract IDs (C-prefix, all alphanumeric).
+    const REGISTRY_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const REGISTRAR_ID: &str = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+    const RESOLVER_ID: &str = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+    const AUCTION_ID: &str = "CDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+    const BRIDGE_ID: &str = "CEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+    const SUBDOMAIN_ID: &str = "CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    const NFT_ID: &str = "CGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG";
+    // Valid 56-char Stellar account addresses (G-prefix, all alphanumeric).
+    const OWNER_ADDR: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const NEW_OWNER_ADDR: &str = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+    const LOOKUP_ADDR: &str = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+
     fn client() -> XlmNsClient {
         XlmNsClient::builder("http://localhost")
             .network_passphrase("Test SDF Network ; September 2015")
-            .registry("CDAD...REGISTRY")
-            .subdomain("CDAD...SUBDOMAIN")
-            .bridge("CDAD...BRIDGE")
-            .auction("CDAD...AUCTION")
-            .registrar("CDAD...REGISTRAR")
-            .resolver("CDAD...RESOLVER")
+            .registry(REGISTRY_ID)
+            .subdomain(SUBDOMAIN_ID)
+            .bridge(BRIDGE_ID)
+            .auction(AUCTION_ID)
+            .registrar(REGISTRAR_ID)
+            .resolver(RESOLVER_ID)
             .build()
     }
 
@@ -60,7 +73,7 @@ mod tests {
         let receipt = client()
             .register(RegistrationRequest {
                 label: "beta".into(),
-                owner: "GDRA...OWNER".into(),
+                owner: OWNER_ADDR.into(),
                 duration_years: 1,
                 signer: Some("treasury".into()),
             })
@@ -123,7 +136,7 @@ mod tests {
         let submission = client()
             .transfer(TransferRequest {
                 name: "foo.xlm".into(),
-                new_owner: "GDRA...NEW".into(),
+                new_owner: NEW_OWNER_ADDR.into(),
                 signer: Some("alice".into()),
             })
             .await
@@ -142,9 +155,9 @@ mod tests {
 
     #[tokio::test]
     async fn owner_portfolio_returns_vec() {
-        let portfolio = client().get_owner_portfolio("GDRA...OWNER").await.unwrap();
+        let portfolio = client().get_owner_portfolio(OWNER_ADDR).await.unwrap();
         assert!(!portfolio.is_empty());
-        assert_eq!(portfolio[0].owner, "GDRA...OWNER");
+        assert_eq!(portfolio[0].owner, OWNER_ADDR);
     }
 
     #[tokio::test]
@@ -167,7 +180,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolver_primary_name_returns_option() {
-        let name = client().get_primary_name("GDRA...ADDR").await.unwrap();
+        let name = client().get_primary_name(LOOKUP_ADDR).await.unwrap();
         assert_eq!(name, Some("primary.xlm".to_string()));
     }
 
@@ -191,7 +204,7 @@ mod tests {
         use std::time::Duration;
 
         let client = XlmNsClient::builder("http://localhost")
-            .registry("CDAD...REGISTRY")
+            .registry(REGISTRY_ID)
             .config(
                 ClientConfig::default()
                     .with_timeout(Duration::from_secs(2))
@@ -220,7 +233,7 @@ mod tests {
         let receipt = client()
             .register(RegistrationRequest {
                 label: "gamma".into(),
-                owner: "GDRA...OWNER".into(),
+                owner: OWNER_ADDR.into(),
                 duration_years: 2,
                 signer: Some("registrar".into()),
             })
@@ -228,7 +241,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(receipt.name, "gamma.xlm");
-        assert_eq!(receipt.owner, "GDRA...OWNER");
+        assert_eq!(receipt.owner, OWNER_ADDR);
         assert_eq!(receipt.duration_years, 2);
         assert_eq!(receipt.fee_paid, 500_000_000); // 250_000_000 × 2
         assert_eq!(receipt.submission.status, SubmissionStatus::Submitted);
@@ -361,7 +374,7 @@ mod tests {
     #[tokio::test]
     async fn quote_requires_registrar_contract() {
         let no_registrar = XlmNsClient::builder("http://localhost")
-            .registry("CDAD...REGISTRY")
+            .registry(REGISTRY_ID)
             .build();
 
         let result = no_registrar.quote_registration("alpha", 1).await;
@@ -376,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn register_requires_registrar_contract() {
         let no_registrar_client = XlmNsClient::builder("http://localhost")
-            .registry("CDAD...REGISTRY")
+            .registry(REGISTRY_ID)
             .build();
 
         let result = no_registrar_client
@@ -400,7 +413,7 @@ mod tests {
     #[tokio::test]
     async fn renew_requires_registrar_contract() {
         let no_registrar_client = XlmNsClient::builder("http://localhost")
-            .registry("CDAD...REGISTRY")
+            .registry(REGISTRY_ID)
             .build();
 
         let result = no_registrar_client
@@ -434,7 +447,7 @@ mod tests {
         let receipt = client()
             .register(RegistrationRequest {
                 label: "epsilon".into(),
-                owner: "GDRA...OWNER".into(),
+                owner: OWNER_ADDR.into(),
                 duration_years: 4,
                 signer: None,
             })
@@ -457,8 +470,167 @@ mod tests {
             )
             .await
             .unwrap();
-        
+
         assert_eq!(submission.status, SubmissionStatus::Submitted);
         assert_eq!(submission.signer.as_deref(), Some("deployer"));
+    }
+
+    // Issue #167 — simulation-first transaction assembly
+
+    #[tokio::test]
+    async fn simulate_register_surfaces_fee_estimate() {
+        // "alpha" = 5 chars → 250_000_000 stroops/year × 2 years
+        let result = client()
+            .simulate_register(&RegistrationRequest {
+                label: "alpha".into(),
+                owner: OWNER_ADDR.into(),
+                duration_years: 2,
+                signer: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.fee_estimate, 500_000_000);
+        assert!(!result.auth_addresses.is_empty());
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn simulate_renew_surfaces_fee_estimate() {
+        let result = client()
+            .simulate_renew(&RenewalRequest {
+                name: "test.xlm".into(),
+                additional_years: 3,
+                signer: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.fee_estimate > 0);
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn simulate_register_requires_registrar_contract() {
+        let no_registrar = XlmNsClient::builder("http://localhost")
+            .registry(REGISTRY_ID)
+            .build();
+
+        let result = no_registrar
+            .simulate_register(&RegistrationRequest {
+                label: "alpha".into(),
+                owner: OWNER_ADDR.into(),
+                duration_years: 1,
+                signer: None,
+            })
+            .await;
+
+        match result {
+            Err(SdkError::InvalidRequest(msg)) => {
+                assert!(msg.contains("registrar"));
+            }
+            _ => panic!("Expected InvalidRequest when registrar contract ID is missing"),
+        }
+    }
+
+    #[tokio::test]
+    async fn simulate_renew_requires_registrar_contract() {
+        let no_registrar = XlmNsClient::builder("http://localhost")
+            .registry(REGISTRY_ID)
+            .build();
+
+        let result = no_registrar
+            .simulate_renew(&RenewalRequest {
+                name: "test.xlm".into(),
+                additional_years: 1,
+                signer: None,
+            })
+            .await;
+
+        match result {
+            Err(SdkError::InvalidRequest(msg)) => {
+                assert!(msg.contains("registrar"));
+            }
+            _ => panic!("Expected InvalidRequest when registrar contract ID is missing"),
+        }
+    }
+
+    // Issue #168 — SDK config expansion
+
+    #[test]
+    fn builder_from_preset_testnet_sets_rpc_and_passphrase() {
+        use crate::config::NetworkPreset;
+        let client = XlmNsClient::builder_from_preset(NetworkPreset::Testnet).build();
+        assert!(client.rpc_url.contains("testnet"));
+        assert_eq!(
+            client.network_passphrase.as_deref(),
+            Some("Test SDF Network ; September 2015")
+        );
+    }
+
+    #[test]
+    fn builder_from_preset_mainnet_sets_rpc_and_passphrase() {
+        use crate::config::NetworkPreset;
+        let client = XlmNsClient::builder_from_preset(NetworkPreset::Mainnet).build();
+        assert!(client.rpc_url.contains("soroban.stellar.org"));
+        assert_eq!(
+            client.network_passphrase.as_deref(),
+            Some("Public Global Stellar Network ; September 2015")
+        );
+    }
+
+    #[test]
+    fn missing_resolver_contract_id_is_none() {
+        let c = XlmNsClient::builder("http://localhost")
+            .registry("CDAD...REGISTRY")
+            .build();
+        assert!(c.resolver_contract_id.is_none());
+    }
+
+    #[test]
+    fn missing_nft_contract_id_is_none() {
+        let c = XlmNsClient::builder("http://localhost").build();
+        assert!(c.nft_contract_id.is_none());
+    }
+
+    #[test]
+    fn missing_bridge_contract_id_is_none() {
+        let c = XlmNsClient::builder("http://localhost").build();
+        assert!(c.bridge_contract_id.is_none());
+    }
+
+    #[test]
+    fn missing_auction_contract_id_is_none() {
+        let c = XlmNsClient::builder("http://localhost").build();
+        assert!(c.auction_contract_id.is_none());
+    }
+
+    #[test]
+    fn missing_subdomain_contract_id_is_none() {
+        let c = XlmNsClient::builder("http://localhost").build();
+        assert!(c.subdomain_contract_id.is_none());
+    }
+
+    #[test]
+    fn fully_specified_builder_sets_all_contract_ids() {
+        let c = XlmNsClient::builder("http://localhost")
+            .registry("CDAD...REGISTRY")
+            .registrar("CDAD...REGISTRAR")
+            .resolver("CDAD...RESOLVER")
+            .auction("CDAD...AUCTION")
+            .bridge("CDAD...BRIDGE")
+            .subdomain("CDAD...SUBDOMAIN")
+            .nft("CDAD...NFT")
+            .build();
+
+        assert!(c.registry_contract_id.is_some());
+        assert!(c.registrar_contract_id.is_some());
+        assert!(c.resolver_contract_id.is_some());
+        assert!(c.auction_contract_id.is_some());
+        assert!(c.bridge_contract_id.is_some());
+        assert!(c.subdomain_contract_id.is_some());
+        assert!(c.nft_contract_id.is_some());
     }
 }

--- a/packages/xlm-ns-sdk/src/types.rs
+++ b/packages/xlm-ns-sdk/src/types.rs
@@ -441,3 +441,19 @@ pub struct BidRequest {
     pub amount: u64,
     pub signer: Option<String>,
 }
+
+/// Typed output from a pre-flight simulation of a write operation.
+///
+/// Call `simulate_register()` or `simulate_renew()` to inspect fees,
+/// auth requirements, and preflight errors before committing a transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimulationResult {
+    /// Estimated fee in stroops that the operation will consume.
+    pub fee_estimate: u64,
+    /// Addresses whose authorization is required for the transaction.
+    pub auth_addresses: Vec<String>,
+    /// Human-readable error message if simulation detected a contract error.
+    pub error: Option<String>,
+    /// `true` when simulation found no errors and the transaction can be submitted.
+    pub success: bool,
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,6 +10,8 @@ xlm-ns-registrar = { path = "../contracts/registrar" }
 xlm-ns-registry  = { path = "../contracts/registry" }
 xlm-ns-resolver  = { path = "../contracts/resolver" }
 xlm-ns-subdomain = { path = "../contracts/subdomain" }
+xlm-ns-auction   = { path = "../contracts/auction" }
+xlm-ns-bridge    = { path = "../contracts/bridge" }
 
 [[test]]
 name = "registrar_registry_test"

--- a/tests/integration/auction_test.rs
+++ b/tests/integration/auction_test.rs
@@ -71,7 +71,7 @@ mod auction_integration {
             .expect("settlement expected");
 
         // Bob should win and pay Charlie's bid amount (Vickrey second-price)
-        assert_eq!(settlement.winner, Some(bob));
+        assert_eq!(settlement.winner, Some(bob.clone()));
         assert_eq!(settlement.winning_bid, 800);
         assert_eq!(settlement.clearing_price, 600);
         assert!(settlement.sold);
@@ -149,7 +149,7 @@ mod auction_integration {
         let settlement = client
             .settle(&name, &time.now)
             .expect("settlement expected");
-        assert_eq!(settlement.winner, Some(alice));
+        assert_eq!(settlement.winner, Some(alice.clone()));
         assert_eq!(settlement.clearing_price, 500); // Clears at reserve
         assert!(settlement.sold);
 

--- a/tests/integration/subdomain_test.rs
+++ b/tests/integration/subdomain_test.rs
@@ -64,7 +64,10 @@ fn subdomain_flow_covers_controller_delegation_transfer_and_resolution() {
 
     let resolved_before_transfer = resolver.resolve(&fqdn).unwrap();
     assert_eq!(resolved_before_transfer.owner, subdomain_owner);
-    assert_eq!(resolved_before_transfer.address, first_address);
+    assert_eq!(
+        resolver.get_stellar_address(&fqdn),
+        Some(first_address.clone())
+    );
     assert_eq!(resolver.reverse(&first_address), Some(fqdn.clone()));
 
     // Transfer subdomain ownership, then update resolver ownership explicitly.
@@ -98,7 +101,10 @@ fn subdomain_flow_covers_controller_delegation_transfer_and_resolution() {
 
     let resolved_after_transfer = resolver.resolve(&fqdn).unwrap();
     assert_eq!(resolved_after_transfer.owner, next_owner);
-    assert_eq!(resolved_after_transfer.address, second_address);
+    assert_eq!(
+        resolver.get_stellar_address(&fqdn),
+        Some(second_address.clone())
+    );
     assert_eq!(resolver.reverse(&second_address), Some(fqdn.clone()));
 
     // Test deletion of subdomain and its effect on resolver (none, resolver record persists)


### PR DESCRIPTION
  ## Summary

  - Closes #142 — `register()` now emits `(registrar, reg)`
  and `renew()` emits `(registrar, renewed)` events, both
  carrying label/name, owner, fee paid, expiry, and
  grace-period timestamps; reserve-label events were already
  in place
  - Closes #147 — `version()` read-only entrypoint
  (`CONTRACT_VERSION = 1`) added to Resolver, Auction, Bridge,
  NFT, and Subdomain contracts; Registry already had
  `storage_schema_version()` and Registrar had
  `pricing_policy_version()`
  - Closes #167 — `SimulationResult { fee_estimate,
  auth_addresses, error, success }` added to SDK types;
  `simulate_register()` and `simulate_renew()` let callers
  inspect fees and auth requirements before submission;
  compile errors in `client.rs` (undefined `ledger`, missing
  `require_label`/`rpc_context`/`make_submission` helpers,
  unused RPC network calls) also fixed
  - Closes #168 — `NetworkPreset { Testnet, Mainnet }` added
  to `config.rs` with `rpc_url()` and `passphrase()`;
  `XlmNsClientBuilder::from_preset()` and
  `XlmNsClient::builder_from_preset()` added; SDK tests now
  cover missing, partial, and fully-specified contract-ID
  configurations

  ## Changes by area

  **Contracts — registrar (#142)**
  - `register()` emits `(registrar, reg)` with `(label, owner,
  payment_stroops, expires_at, grace_period_ends_at)`
  - `renew()` emits `(registrar, renewed)` with `(name,
  caller, payment_stroops, expires_at, grace_period_ends_at)`
  - Registrar unit tests gain `env.mock_all_auths()` where
  cross-contract auth was missing; two event-emission tests
  added

  **Contracts — version surface (#147)**
  - `pub const CONTRACT_VERSION: u32 = 1;` and `pub fn
  version(_env: Env) -> u32` added to Resolver, Auction,
  Bridge, NFT, and Subdomain
  - One `version_is_exposed` test added per contract

  **SDK — simulation-first flow (#167)**
  - `SimulationResult` exported from `xlm_ns_sdk`
  - `simulate_register()` / `simulate_renew()` on
  `XlmNsClient`
  - Fixed: `require_label()`, `rpc_context()`,
  `make_submission()` helpers; `ledger` undefined;
  `SystemTime`/`UNIX_EPOCH` import; unnecessary
  `rpc.get_network()` calls removed from mock paths
  - Tests for simulation success, fee estimates, and
  missing-registrar guard added

  **SDK — config expansion (#168)**
  - `NetworkPreset` exported from `xlm_ns_sdk`
  - `XlmNsClientBuilder::from_preset(preset)` and
  `XlmNsClient::builder_from_preset(preset)` added
  - Tests: testnet/mainnet preset construction,
  missing/partial/fully-specified contract-ID coverage

  **Pre-existing fixes (unblocked by the issues above)**
  - SDK test contract IDs updated to valid 56-char Stellar
  format
  - `xlm-ns-auction` and `xlm-ns-bridge` added to integration
  test dev-dependencies
  - `ResolutionRecord.address` → `get_stellar_address()` in
  subdomain integration test
  - `proptest` added as dev-dependency to `xlm-ns-common`
  - Auction test borrow-after-move and wrong-arg-count
  `create_auction` calls fixed
  - Bridge test updated: `register_chain` is permissionless
  (no auth in contract)
  - `batch_resolve` test: `results.get(2)` correctly asserts
  `Some(None)` for a present-but-empty slot

  ## Test plan
  - [x] `cargo test --workspace` — all tests pass (0 failures)
  - [x] Registrar: `register_emits_registered_event`,
  `renew_emits_renewed_event`
  - [x] Resolver/Auction/Bridge/NFT/Subdomain:
  `version_is_exposed`
  - [x] SDK: `simulate_register_surfaces_fee_estimate`,
  `simulate_renew_surfaces_fee_estimate`,
  `simulate_register_requires_registrar_contract`,
  `simulate_renew_requires_registrar_contract`
  - [x] SDK:
  `builder_from_preset_testnet_sets_rpc_and_passphrase`,
  `builder_from_preset_mainnet_sets_rpc_and_passphrase`,
  `fully_specified_builder_sets_all_contract_ids`,
  missing-contract-id guards


Closes #142 
Closes #147 
Closes #167 
Closes #168 