### PR TITLE
feat: paginate CLI portfolio results

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Examples:
 - `cargo run -p xlm-ns-cli -- resolve timmy.xlm --output json`
 - `cargo run -p xlm-ns-cli -- whois timmy.xlm --output json`
 - `cargo run -p xlm-ns-cli -- portfolio GDRA...OWNER_ADDR --output json`
-- `cargo run -p xlm-ns-cli -- portfolio GDRA...OWNER_ADDR --output csv`
+- `cargo run -p xlm-ns-cli -- portfolio GDRA...OWNER_ADDR --batch-size 50 --limit 200`
+- `cargo run -p xlm-ns-cli -- portfolio GDRA...OWNER_ADDR --page 3 --output csv`
 
 #### Contract spec artifacts (CI)
 

--- a/cli/src/commands/portfolio.rs
+++ b/cli/src/commands/portfolio.rs
@@ -3,7 +3,38 @@ use crate::export;
 use crate::output::{emit_error, OutputFormat};
 use serde_json::json;
 use xlm_ns_sdk::client::XlmNsClient;
+use xlm_ns_sdk::errors::SdkError;
 use xlm_ns_sdk::types::{RegistryEntry, ResolutionResult};
+
+const DEFAULT_BATCH_SIZE: usize = 50;
+const MIN_BATCH_SIZE: usize = 1;
+
+#[derive(Debug, Clone, Copy)]
+pub struct PortfolioOptions {
+    pub batch_size: usize,
+    pub limit: Option<usize>,
+    pub page: Option<usize>,
+}
+
+impl Default for PortfolioOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: DEFAULT_BATCH_SIZE,
+            limit: None,
+            page: None,
+        }
+    }
+}
+
+impl PortfolioOptions {
+    pub fn normalized(self) -> Self {
+        Self {
+            batch_size: self.batch_size.max(MIN_BATCH_SIZE),
+            limit: self.limit,
+            page: self.page,
+        }
+    }
+}
 
 async fn build_portfolio_records(
     client: &XlmNsClient,
@@ -32,11 +63,45 @@ async fn build_portfolio_records(
     Ok(records)
 }
 
+fn is_timeout_error(err: &SdkError) -> bool {
+    match err {
+        SdkError::Transport(message) | SdkError::InvalidRequest(message) => {
+            let message = message.to_ascii_lowercase();
+            message.contains("timeout") || message.contains("timed out")
+        }
+        SdkError::TransactionTimeout { .. } => true,
+        _ => false,
+    }
+}
+
+fn progress(output: OutputFormat, fetched: usize, total: usize) {
+    if output == OutputFormat::Human {
+        eprintln!("Fetched {fetched}/{total} names...");
+    }
+}
+
+fn print_human_batch(owner: &str, names: &[ResolutionResult], printed_header: &mut bool) {
+    if !*printed_header {
+        println!("Portfolio for {owner}:");
+        *printed_header = true;
+    }
+
+    for entry in names {
+        let expires = entry
+            .expires_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        println!("  - {} (expires_at: {expires})", entry.name);
+    }
+}
+
 pub async fn run_portfolio(
     config: NetworkConfig,
     output: OutputFormat,
     owner: &str,
+    options: PortfolioOptions,
 ) -> anyhow::Result<()> {
+    let options = options.normalized();
     let now_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -57,47 +122,110 @@ pub async fn run_portfolio(
             .unwrap_or_else(|| "unknown".to_string()),
     );
 
-    match client.list_registrations_by_owner(owner) {
-        Ok(names) => match output {
-            OutputFormat::Human => {
-                let mut lines = vec![format!("Portfolio for {owner}:")];
-                if names.is_empty() {
-                    lines.push("  [no names found]".to_string());
-                } else {
-                    for entry in &names {
-                        let expires = entry
-                            .expires_at
-                            .map(|value| value.to_string())
-                            .unwrap_or_else(|| "unknown".to_string());
-                        lines.push(format!("  - {} (expires_at: {expires})", entry.name));
-                    }
-                }
+    let mut cursor = options
+        .page
+        .map(|page| page.saturating_sub(1) * options.batch_size);
+    let mut page_size = options.batch_size;
+    let mut fetched = 0usize;
+    let mut total_seen = None;
+    let mut names = Vec::new();
+    let mut printed_header = false;
 
-                println!("{}", lines.join("\n"));
+    loop {
+        let remaining_limit = options.limit.map(|limit| limit.saturating_sub(fetched));
+        if remaining_limit == Some(0) {
+            break;
+        }
+        let page = loop {
+            let requested = remaining_limit.map_or(page_size, |remaining| remaining.min(page_size));
+            match client.list_registrations_by_owner_page(owner, cursor, requested) {
+                Ok(page) => break page,
+                Err(err) if is_timeout_error(&err) && page_size > MIN_BATCH_SIZE => {
+                    page_size = (page_size / 2).max(MIN_BATCH_SIZE);
+                    eprintln!(
+                        "RPC timed out while fetching portfolio; retrying with batch size {page_size}"
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    let message = format!("ERROR: Failed to fetch portfolio for {owner}: {err}");
+                    emit_error(
+                        output,
+                        &message,
+                        json!({
+                            "error": message,
+                            "owner": owner,
+                            "registry_contract_id": config.registry_contract_id,
+                            "rpc_url": config.rpc_url,
+                            "network": config.network.as_str(),
+                        }),
+                    );
+                    return Ok(());
+                }
             }
-            OutputFormat::Json => {
-                let records = build_portfolio_records(&client, &names, now_unix).await?;
-                export::write_json(&records, &mut std::io::stdout()).map_err(anyhow::Error::msg)?;
-            }
-            OutputFormat::Csv => {
-                let records = build_portfolio_records(&client, &names, now_unix).await?;
-                export::write_csv(&records, &mut std::io::stdout()).map_err(anyhow::Error::msg)?;
-            }
-        },
-        Err(err) => {
-            let message = format!("ERROR: Failed to fetch portfolio for {owner}: {err}");
-            emit_error(
-                output,
-                &message,
-                json!({
-                    "error": message,
-                    "owner": owner,
-                    "registry_contract_id": config.registry_contract_id,
-                    "rpc_url": config.rpc_url,
-                    "network": config.network.as_str(),
-                }),
-            );
+        };
+
+        total_seen = Some(page.total);
+        if output == OutputFormat::Human {
+            print_human_batch(owner, &page.items, &mut printed_header);
+        }
+        fetched += page.items.len();
+        names.extend(page.items);
+        progress(output, fetched, page.total);
+
+        if options.page.is_some() || cursor == page.next_cursor || page.next_cursor.is_none() {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    if names.is_empty() && output == OutputFormat::Human {
+        println!("Portfolio for {owner}:\n  [no names found]");
+        if let Some(total) = total_seen {
+            progress(output, 0, total);
         }
     }
+
+    match output {
+        OutputFormat::Human => {}
+        OutputFormat::Json => {
+            let records = build_portfolio_records(&client, &names, now_unix).await?;
+            export::write_json(&records, &mut std::io::stdout()).map_err(anyhow::Error::msg)?;
+        }
+        OutputFormat::Csv => {
+            let records = build_portfolio_records(&client, &names, now_unix).await?;
+            export::write_csv(&records, &mut std::io::stdout()).map_err(anyhow::Error::msg)?;
+        }
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portfolio_options_clamps_zero_batch_size() {
+        let options = PortfolioOptions {
+            batch_size: 0,
+            limit: Some(10),
+            page: Some(1),
+        }
+        .normalized();
+
+        assert_eq!(options.batch_size, 1);
+        assert_eq!(options.limit, Some(10));
+        assert_eq!(options.page, Some(1));
+    }
+
+    #[test]
+    fn detects_timeout_errors_for_retry() {
+        assert!(is_timeout_error(&SdkError::Transport(
+            "request timed out".to_string()
+        )));
+        assert!(!is_timeout_error(&SdkError::InvalidRequest(
+            "owner must not be empty".to_string()
+        )));
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -145,6 +145,15 @@ enum Commands {
     Portfolio {
         /// Owner address to inspect
         owner: String,
+        /// Number of names to fetch per RPC request.
+        #[arg(long = "batch-size", default_value_t = 50)]
+        batch_size: usize,
+        /// Maximum number of names to return.
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Fetch a single 1-based page instead of the whole portfolio.
+        #[arg(long)]
+        page: Option<usize>,
     },
     /// Fetch a registration price quote without submitting a transaction (read-only).
     ///
@@ -505,8 +514,18 @@ async fn run() -> anyhow::Result<()> {
             }
         },
         Commands::Whois { name } => commands::whois::run_whois(config, cli.output, &name).await,
-        Commands::Portfolio { owner } => {
-            commands::portfolio::run_portfolio(config, cli.output, &owner).await
+        Commands::Portfolio {
+            owner,
+            batch_size,
+            limit,
+            page,
+        } => {
+            let options = commands::portfolio::PortfolioOptions {
+                batch_size,
+                limit,
+                page,
+            };
+            commands::portfolio::run_portfolio(config, cli.output, &owner, options).await
         }
         Commands::Quote { name, years } => {
             commands::quote::run_quote(config, cli.output, &name, years).await

--- a/docs/testnet-operator-runbook.md
+++ b/docs/testnet-operator-runbook.md
@@ -94,6 +94,11 @@ cargo run -p xlm-ns-cli -- portfolio OWNER_ADDRESS --output json
 # CSV — suitable for spreadsheets or data pipelines
 cargo run -p xlm-ns-cli -- portfolio OWNER_ADDRESS --output csv \
   > owner-export.csv
+
+# Large portfolios are fetched in pages of 50 by default. Tune the page size,
+# cap the export, or request one 1-based page when operating on registrar/DAO wallets.
+cargo run -p xlm-ns-cli -- portfolio OWNER_ADDRESS --batch-size 25 --limit 100
+cargo run -p xlm-ns-cli -- portfolio OWNER_ADDRESS --page 2 --output json
 ```
 
 Each record includes: `name`, `owner`, `resolver`,

--- a/packages/xlm-ns-sdk/src/blocking.rs
+++ b/packages/xlm-ns-sdk/src/blocking.rs
@@ -29,7 +29,7 @@ use crate::config::ClientConfig;
 use crate::errors::SdkError;
 use crate::types::{
     AddControllerRequest, AuctionCreateRequest, AuctionInfo, BidRequest, BridgeRoute,
-    BuildMessageRequest, CreateSubdomainRequest, NftRecord, RegisterChainRequest,
+    BuildMessageRequest, CreateSubdomainRequest, NftRecord, PortfolioPage, RegisterChainRequest,
     RegisterParentRequest, RegistrationQuote, RegistrationReceipt, RegistrationRequest,
     RenewalReceipt, RenewalRequest, ResolutionResult, ReverseResolution, TextRecord,
     TextRecordUpdate, TextRecordsUpdate, TransactionSubmission, TransferRequest,
@@ -120,6 +120,16 @@ impl XlmNsBlockingClient {
         owner: &str,
     ) -> Result<Vec<ResolutionResult>, SdkError> {
         self.inner.list_registrations_by_owner(owner)
+    }
+
+    pub fn list_registrations_by_owner_page(
+        &self,
+        owner: &str,
+        cursor: Option<usize>,
+        limit: usize,
+    ) -> Result<PortfolioPage, SdkError> {
+        self.inner
+            .list_registrations_by_owner_page(owner, cursor, limit)
     }
 
     pub fn reverse_resolve(&self, address: &str) -> Result<ReverseResolution, SdkError> {

--- a/packages/xlm-ns-sdk/src/client.rs
+++ b/packages/xlm-ns-sdk/src/client.rs
@@ -4,11 +4,11 @@ use crate::network;
 use crate::types::{
     AddControllerRequest, AuctionCreateRequest, AuctionInfo, AuctionState, AuctionStatus,
     BidRequest, BridgeRoute, BuildMessageRequest, CreateSubdomainRequest, FeeBreakdown, NameRecord,
-    NftRecord, RegisterChainRequest, RegisterParentRequest, RegistrarMetrics, RegistrationQuote,
-    RegistrationReceipt, RegistrationRequest, RegistryEntry, RenewalReceipt, RenewalRequest,
-    ResolutionRecord, ResolutionResult, ReverseResolution, SimulationResult, Subdomain,
-    SubmissionStatus, TextRecord, TextRecordUpdate, TextRecordsUpdate, TransactionSubmission,
-    TransferRequest, TransferSubdomainRequest, DEFAULT_FEE_CURRENCY,
+    NftRecord, PortfolioPage, RegisterChainRequest, RegisterParentRequest, RegistrarMetrics,
+    RegistrationQuote, RegistrationReceipt, RegistrationRequest, RegistryEntry, RenewalReceipt,
+    RenewalRequest, ResolutionRecord, ResolutionResult, ReverseResolution, SimulationResult,
+    Subdomain, SubmissionStatus, TextRecord, TextRecordUpdate, TextRecordsUpdate,
+    TransactionSubmission, TransferRequest, TransferSubdomainRequest, DEFAULT_FEE_CURRENCY,
 };
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
@@ -353,9 +353,25 @@ impl XlmNsClient {
         &self,
         owner: &str,
     ) -> Result<Vec<ResolutionResult>, SdkError> {
+        let first_page = self.list_registrations_by_owner_page(owner, None, usize::MAX)?;
+        Ok(first_page.items)
+    }
+
+    pub fn list_registrations_by_owner_page(
+        &self,
+        owner: &str,
+        cursor: Option<usize>,
+        limit: usize,
+    ) -> Result<PortfolioPage, SdkError> {
         Self::require_label(owner, "owner")?;
 
-        Ok(vec![
+        if limit == 0 {
+            return Err(SdkError::InvalidRequest(
+                "portfolio page size must be greater than zero".into(),
+            ));
+        }
+
+        let all_items = vec![
             ResolutionResult {
                 name: "alice.xlm".to_string(),
                 address: Some(owner.to_string()),
@@ -368,7 +384,17 @@ impl XlmNsClient {
                 resolver: self.resolver_contract_id.clone(),
                 expires_at: Some(MOCK_REFERENCE_TIMESTAMP + (2 * SECONDS_PER_YEAR)),
             },
-        ])
+        ];
+        let total = all_items.len();
+        let start = cursor.unwrap_or_default().min(total);
+        let end = start.saturating_add(limit).min(total);
+        let next_cursor = (end < total).then_some(end);
+
+        Ok(PortfolioPage {
+            items: all_items[start..end].to_vec(),
+            next_cursor,
+            total,
+        })
     }
 
     pub async fn reverse_resolve(&self, address: &str) -> Result<ReverseResolution, SdkError> {

--- a/packages/xlm-ns-sdk/src/tests.rs
+++ b/packages/xlm-ns-sdk/src/tests.rs
@@ -186,6 +186,23 @@ mod tests {
         assert_eq!(portfolio[0].owner, OWNER_ADDR);
     }
 
+    #[test]
+    fn owner_portfolio_page_returns_cursor_and_total() {
+        let first = client()
+            .list_registrations_by_owner_page(OWNER_ADDR, None, 1)
+            .unwrap();
+        assert_eq!(first.items.len(), 1);
+        assert_eq!(first.total, 2);
+        assert_eq!(first.next_cursor, Some(1));
+
+        let second = client()
+            .list_registrations_by_owner_page(OWNER_ADDR, first.next_cursor, 1)
+            .unwrap();
+        assert_eq!(second.items.len(), 1);
+        assert_eq!(second.total, 2);
+        assert_eq!(second.next_cursor, None);
+    }
+
     #[tokio::test]
     async fn auction_state_returns_typed_data() {
         let state = client().get_auction_state("active.xlm").await.unwrap();

--- a/packages/xlm-ns-sdk/src/types.rs
+++ b/packages/xlm-ns-sdk/src/types.rs
@@ -259,6 +259,13 @@ pub struct ResolutionResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortfolioPage {
+    pub items: Vec<ResolutionResult>,
+    pub next_cursor: Option<usize>,
+    pub total: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReverseResolution {
     pub address: String,
     pub primary_name: Option<String>,


### PR DESCRIPTION
Closes #467 

## Summary
- The `portfolio` CLI previously fetched all names in a single RPC call which times out for large owners; pagination is needed to handle large portfolios reliably and show progress.

### Description
- Add `--batch-size`, `--limit`, and `--page` flags and a `PortfolioOptions` type to the CLI to control cursor-based fetching and page size. 
- Implement cursor-based pagination in `cli/src/commands/portfolio.rs` that streams human-readable batches as they arrive and prints fetched/total progress. 
- Detect RPC timeout-like errors and automatically retry the request with a halved batch size until a minimum batch size is reached. 
- Extend the SDK with a `PortfolioPage` type and `list_registrations_by_owner_page` API, plus a blocking-client wrapper method, while keeping `list_registrations_by_owner` behavior intact. 
- Add tests for option normalization, timeout detection, and SDK pagination behavior, and update documentation examples in `README.md` and the testnet runbook.

### Testing
- Ran `cargo fmt` successfully to format changes. 
- Executed the automated test suites with `cargo test -p xlm-ns-sdk -p xlm-ns-cli`, and all tests passed for both crates.
