### PR TITLE
ops: add log aggregation for canary test results

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -18,9 +18,18 @@ jobs:
             rpc_url: https://soroban-rpc.mainnet.stellar.org
     steps:
       - uses: actions/checkout@v4
+
       - name: Canary (${{ matrix.name }})
         env:
           SOROBAN_RPC_URL: ${{ matrix.rpc_url }}
-        run: |
-          bash scripts/canary/public_endpoints.sh
+          CANARY_NETWORK: ${{ matrix.name }}
+          CANARY_LOG_FILE: canary-results.ndjson
+        run: bash scripts/canary/public_endpoints.sh
 
+      - name: Upload canary log (${{ matrix.name }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-log-${{ matrix.name }}-${{ github.run_id }}
+          path: canary-results.ndjson
+          retention-days: 90

--- a/scripts/canary/public_endpoints.sh
+++ b/scripts/canary/public_endpoints.sh
@@ -2,20 +2,49 @@
 set -euo pipefail
 
 RPC_URL="${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}"
+NETWORK="${CANARY_NETWORK:-testnet}"
+LOG_FILE="${CANARY_LOG_FILE:-canary-results.ndjson}"
+
+# Emit one JSON entry and append it to the log file.
+# Usage: record_result <test_name> <pass|fail> <duration_ms> [error_msg]
+record_result() {
+  local name="$1" result="$2" duration="$3" error="${4:-}"
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local entry
+  entry=$(printf '{"timestamp":"%s","network":"%s","test":"%s","result":"%s","duration_ms":%s,"error":%s}' \
+    "$ts" "$NETWORK" "$name" "$result" "$duration" \
+    "$([ -n "$error" ] && printf '"%s"' "${error//\"/\\\"}" || echo 'null')")
+  echo "$entry" | tee -a "$LOG_FILE"
+}
+
+# Run a single test, measure duration, record outcome.
+run_test() {
+  local name="$1"; shift
+  local t0 t1 duration output rc
+  t0=$(date +%s%3N)
+  output=$("$@" 2>&1) && rc=0 || rc=$?
+  t1=$(date +%s%3N)
+  duration=$(( t1 - t0 ))
+  if [ "$rc" -eq 0 ]; then
+    record_result "$name" "pass" "$duration"
+  else
+    record_result "$name" "fail" "$duration" "$output"
+  fi
+  return "$rc"
+}
 
 jsonrpc() {
   local method="$1"
-  curl -fsS -H 'content-type: application/json' \
+  curl -fsS --max-time 15 -H 'content-type: application/json' \
     --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"${method}\"}" \
     "${RPC_URL}"
 }
 
-echo "Canary: RPC health check"
-echo "  SOROBAN_RPC_URL=${RPC_URL}"
+echo "Canary: RPC health check  network=${NETWORK}  url=${RPC_URL}  log=${LOG_FILE}" >&2
 
-# Non-destructive endpoint checks to catch integration drift early.
-jsonrpc getHealth >/dev/null
-jsonrpc getNetwork >/dev/null
+overall=0
+run_test "rpc_getHealth"   jsonrpc getHealth   || overall=1
+run_test "rpc_getNetwork"  jsonrpc getNetwork  || overall=1
 
-echo "OK"
-
+[ "$overall" -eq 0 ] && echo "OK" >&2 || { echo "FAILED" >&2; exit 1; }

--- a/scripts/canary/xlm-ns-canary
+++ b/scripts/canary/xlm-ns-canary
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# xlm-ns-canary — log analysis tool for canary test results
+# Usage:
+#   xlm-ns-canary report  [--log FILE] [--since DATE] [--until DATE]
+#   xlm-ns-canary compare [--log FILE] <date1> <date2>
+set -euo pipefail
+
+LOG_FILE="${CANARY_LOG_FILE:-canary-results.ndjson}"
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  $(basename "$0") report  [--log FILE] [--since DATE] [--until DATE]
+  $(basename "$0") compare [--log FILE] <date1> <date2>
+
+Options:
+  --log FILE    Path to NDJSON log file (default: canary-results.ndjson)
+  --since DATE  ISO date lower bound for report  (e.g. 2026-06-01)
+  --until DATE  ISO date upper bound for report  (e.g. 2026-06-22)
+
+compare DATE format: YYYY-MM-DD  (matches any run whose timestamp starts with that date)
+EOF
+  exit 1
+}
+
+# Filter NDJSON by optional date bounds (prefix match on timestamp field).
+filter_range() {
+  local since="$1" until="$2"
+  jq -c --arg s "$since" --arg u "$until" '
+    select(
+      ($s == "" or .timestamp >= $s) and
+      ($u == "" or .timestamp <= ($u + "T99"))
+    )
+  '
+}
+
+cmd_report() {
+  local since="" until=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --log)   LOG_FILE="$2"; shift 2 ;;
+      --since) since="$2";    shift 2 ;;
+      --until) until="$2";    shift 2 ;;
+      *) usage ;;
+    esac
+  done
+
+  [[ -f "$LOG_FILE" ]] || { echo "Log not found: $LOG_FILE" >&2; exit 1; }
+
+  filter_range "$since" "$until" < "$LOG_FILE" | jq -s '
+    def pct(n;d): if d == 0 then 0 else ((n / d) * 100 | round) end;
+
+    # --- overall summary ---
+    {
+      total:   length,
+      passed:  (map(select(.result=="pass")) | length),
+      failed:  (map(select(.result=="fail")) | length),
+    } as $totals |
+
+    # --- per-test stats ---
+    (group_by(.test) | map({
+      test:        .[0].test,
+      runs:        length,
+      passes:      (map(select(.result=="pass")) | length),
+      failures:    (map(select(.result=="fail")) | length),
+      pass_rate:   (pct(map(select(.result=="pass")) | length; length) | tostring + "%"),
+      avg_ms:      (map(.duration_ms) | add / length | round),
+      p95_ms:      (sort_by(.duration_ms) | .[ (length * 0.95 | floor) ].duration_ms),
+      last_error:  (map(select(.result=="fail" and .error != null)) | last | .error // null),
+    })) as $by_test |
+
+    # --- latency trend: mean per calendar day ---
+    (group_by(.timestamp[0:10]) | map({
+      date: .[0].timestamp[0:10],
+      avg_ms: (map(.duration_ms) | add / length | round),
+      pass_rate: (pct(map(select(.result=="pass")) | length; length) | tostring + "%"),
+    })) as $trend |
+
+    {
+      summary: ($totals + {pass_rate: (pct($totals.passed; $totals.total) | tostring + "%")}),
+      by_test: $by_test,
+      daily_trend: $trend,
+    }
+  '
+}
+
+cmd_compare() {
+  local date1="" date2=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --log) LOG_FILE="$2"; shift 2 ;;
+      -*)    usage ;;
+      *)
+        if   [[ -z "$date1" ]]; then date1="$1"
+        elif [[ -z "$date2" ]]; then date2="$1"
+        else usage
+        fi
+        shift ;;
+    esac
+  done
+  [[ -n "$date1" && -n "$date2" ]] || usage
+  [[ -f "$LOG_FILE" ]] || { echo "Log not found: $LOG_FILE" >&2; exit 1; }
+
+  # Extract one JSON array per date, then diff pass rates and avg latency.
+  jq -s --arg d1 "$date1" --arg d2 "$date2" '
+    def stats(rows):
+      (rows | length) as $n |
+      if $n == 0 then {runs: 0, pass_rate: "n/a", avg_ms: null}
+      else {
+        runs: $n,
+        pass_rate: (((rows | map(select(.result=="pass")) | length) / $n * 100 | round) | tostring + "%"),
+        avg_ms: (rows | map(.duration_ms) | add / $n | round),
+      }
+      end;
+
+    . as $all |
+    ($all | map(select(.timestamp[0:10] == $d1))) as $a |
+    ($all | map(select(.timestamp[0:10] == $d2))) as $b |
+    (($a + $b) | map(.test) | unique) |
+    map(. as $t | {
+      test: $t,
+      ($d1): stats($a | map(select(.test == $t))),
+      ($d2): stats($b | map(select(.test == $t))),
+    })
+  ' < "$LOG_FILE"
+}
+
+[[ $# -gt 0 ]] || usage
+cmd="$1"; shift
+case "$cmd" in
+  report)  cmd_report  "$@" ;;
+  compare) cmd_compare "$@" ;;
+  *)       usage ;;
+esac


### PR DESCRIPTION
closes #496 
Summary of what that was done:
- Rewrite public_endpoints.sh to time each test and append a structured NDJSON entry (timestamp, network, test, result, duration_ms, error) to CANARY_LOG_FILE (default: canary-results.ndjson).

- Add scripts/canary/xlm-ns-canary CLI with two subcommands: report  [--log] [--since] [--until]  — overall pass rate, per-test pass rate / avg latency / p95 / last error, daily trend table.
    compare [--log] <date1> <date2>      — side-by-side diff of pass rate
            and avg latency per test between two calendar days.

- Update nightly-canary.yml to upload canary-results.ndjson as a 90-day retained artifact after every run (runs on failure too), one artifact per network per workflow run.

Closes #canary-log-aggregation
Related: #70 #68 #60

## Summary

<!-- Describe what this PR changes and why. -->

Closes #<!-- issue number -->

## Change type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Contract change

## Areas affected

- [ ] CLI (`cli/`)
- [ ] Contracts (`contracts/`)
- [ ] SDK (`packages/xlm-ns-sdk/`)
- [ ] Common types (`packages/xlm-ns-common/`)
- [ ] CI / GitHub Actions
- [ ] Docs

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] Contract changes: `cargo build --release --target wasm32-unknown-unknown` succeeds
- [ ] New functionality covered by tests or snapshots
- [ ] Manually verified on testnet (for contract / CLI changes)

## Rollout notes

<!-- Anything reviewers or deployers should know: breaking changes, migration steps, env var changes. -->
<!-- Delete this section if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] No secrets or credentials committed
- [ ] PR title is descriptive
- [ ] Linked the issue above
