### PR TITLE
Add CI step to check contract WASM size against budget

### DIFF
--- a/.github/contract-size-budget.json
+++ b/.github/contract-size-budget.json
@@ -1,0 +1,9 @@
+[
+  { "name": "xlm_ns_registry", "max_size_bytes": 65536 },
+  { "name": "xlm_ns_registrar", "max_size_bytes": 65536 },
+  { "name": "xlm_ns_resolver", "max_size_bytes": 65536 },
+  { "name": "xlm_ns_auction", "max_size_bytes": 65536 },
+  { "name": "xlm_ns_subdomain", "max_size_bytes": 65536 },
+  { "name": "xlm_ns_nft", "max_size_bytes": 65536 },
+  { "name": "xlm_ns_bridge", "max_size_bytes": 65536 }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,13 @@ jobs:
             fi
             echo "OK: $wasm ($(wc -c < "$wasm") bytes)"
           done
+      - name: Check contract WASM size budget
+        run: ./scripts/check-contract-size.sh
       - name: Collect artifacts
         run: |
           mkdir -p artifacts/wasm artifacts/specs
           cp target/wasm32-unknown-unknown/release/xlm_ns_*.wasm artifacts/wasm/
+            cp artifacts/contract-size-report.md artifacts/ 2>/dev/null || true
 
           # Generate contract specs for each WASM
           for wasm in artifacts/wasm/*.wasm; do

--- a/scripts/check-contract-size.sh
+++ b/scripts/check-contract-size.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="${1:-.github/contract-size-budget.json}"
+WASM_DIR="${2:-target/wasm32-unknown-unknown/release}"
+MARKDOWN_FILE="${3:-artifacts/contract-size-report.md}"
+
+echo "Checking contract WASM sizes against budget..."
+echo "Config: $CONFIG_FILE"
+echo "WASM directory: $WASM_DIR"
+echo "Markdown report will be written to: $MARKDOWN_FILE"
+
+# Ensure jq is available
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed." >&2
+    exit 1
+fi
+
+# Read config into arrays
+CONTRACTS=()
+while IFS= read -r line; do
+    CONTRACTS+=("$line")
+done < <(jq -r '.[] | .name' "$CONFIG_FILE")
+
+MAX_SIZES=()
+while IFS= read -r line; do
+    MAX_SIZES+=("$line")
+done < <(jq -r '.[] | .max_size_bytes' "$CONFIG_FILE")
+
+# Ensure arrays have same length
+if [ "${#CONTRACTS[@]}" -ne "${#MAX_SIZES[@]}" ]; then
+    echo "Error: mismatched lengths in config" >&2
+    exit 1
+fi
+
+# Ensure output directory exists
+mkdir -p "$(dirname "$MARKDOWN_FILE")"
+
+# Markdown report
+{
+    echo "| Contract | Size (bytes) | Budget (bytes) | Status |"
+    echo "|----------|--------------|----------------|--------|"
+    FAILED=0
+    for i in "${!CONTRACTS[@]}"; do
+        contract="${CONTRACTS[$i]}"
+        max="${MAX_SIZES[$i]}"
+        wasm_file="${WASM_DIR}/${contract}.wasm"
+        if [[ ! -f "$wasm_file" ]]; then
+            echo "| $contract | MISSING | $max | ❌ Missing |"
+            FAILED=1
+            continue
+        fi
+        size=$(wc -c < "$wasm_file")
+        if (( size > max )); then
+            status="❌ OVER ($((size - max)) bytes over)"
+            FAILED=1
+        else
+            status="✅ OK"
+        fi
+        printf "| %s | %'d | %'d | %s |\n" "$contract" "$size" "$max" "$status"
+    done
+} > "$MARKDOWN_FILE"
+
+echo "Report written to $MARKDOWN_FILE"
+cat "$MARKDOWN_FILE"
+
+if (( FAILED )); then
+    echo "::error::One or more contracts exceed the WASM size budget."
+    exit 1
+else
+    echo "All contracts within size limits."
+fi


### PR DESCRIPTION
- Add JSON config file .github/contract-size-budget.json with size limits for each contract (default 65536 bytes)
- Add script scripts/check-contract-size.sh that reads the config, measures WASM sizes, outputs a markdown table, and fails if any contract exceeds its budget
- Insert a step into the CI workflow (artifacts job) after verifying WASM outputs to run the size check
- The script also writes a markdown report to artifacts/contract-size-report.md for visibility

This ensures CI will fail early if any contract grows beyond the allowed size, preventing surprises during deployment.


closes #412 
